### PR TITLE
feat: support wl mainnet deploy token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ python3 setup.py install
 
 ## Quick Usage
 
+### Account Management
+
 Deploy a new account:
 
 ```bash
@@ -74,6 +76,29 @@ ape starknet accounts delete <ALIAS> --network starknet:testnet
 ```
 
 **NOTE**: You don't have to specify the network if your account is only deployed to a single network.
+
+### Mainnet Alpha Whitelist Deployment Token
+
+Currently, to deploy to Alpha-Mainnet, your contract needs to be whitelisted.
+You can provide your WL token in a variety of ways.
+
+Via Python code:
+
+```python
+my_contract = project.MyContract.deploy(token="MY_TOKEN")
+```
+
+Via an Environment Variable:
+
+```bash
+export ALPHA_MAINNET_WL_DEPLOY_TOKEN="MY_TOKEN"
+```
+
+Or, via the `--token` flag when deploying an account:
+
+```bash
+ape starknet accounts create MY_ACCOUNT --token MY_TOKEN
+```
 
 ## Development
 

--- a/ape_starknet/_utils.py
+++ b/ape_starknet/_utils.py
@@ -25,6 +25,7 @@ NETWORKS = {
 }
 _HEX_ADDRESS_REG_EXP = re.compile("(0x)?[0-9a-f]*", re.IGNORECASE | re.ASCII)
 """Same as from eth-utils except not limited length."""
+ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY = "ALPHA_MAINNET_WL_DEPLOY_TOKEN"
 
 
 def get_chain_id(network_id: Union[str, int]) -> StarknetChainId:

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -1,4 +1,5 @@
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union
@@ -25,7 +26,12 @@ from starknet_py.utils.crypto.facade import sign_calldata  # type: ignore
 from starkware.cairo.lang.vm.cairo_runner import verify_ecdsa_sig  # type: ignore
 from starkware.crypto.signature.signature import get_random_private_key  # type: ignore
 
-from ape_starknet._utils import PLUGIN_NAME, get_chain_id, handle_client_errors
+from ape_starknet._utils import (
+    ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY,
+    PLUGIN_NAME,
+    get_chain_id,
+    handle_client_errors,
+)
 from ape_starknet.provider import StarknetProvider
 from ape_starknet.tokens import TokenManager
 from ape_starknet.transactions import InvokeFunctionTransaction, StarknetTransaction
@@ -174,13 +180,16 @@ class StarknetAccountContracts(AccountContainerAPI):
             new_account = StarknetKeyfileAccount(key_file_path=path)
             new_account.write(passphrase=None, private_key=private_key, deployments=deployments)
 
-    def deploy_account(self, alias: str, private_key: Optional[int] = None) -> str:
+    def deploy_account(
+        self, alias: str, private_key: Optional[int] = None, token: Optional[str] = None
+    ) -> str:
         """
         Deploys an account contract for the given alias.
 
         Args:
             alias (str): The alias to use to reference the account in ``ape``.
             private_key (Optional[int]): Optionally provide your own private key.`
+            token (Optional[str]): Used for deploying contracts in Alpha MainNet.
 
         Returns:
             str: The contract address of the account.
@@ -196,7 +205,7 @@ class StarknetAccountContracts(AccountContainerAPI):
         key_pair = KeyPair.from_private_key(private_key)
 
         contract_address = self.provider._deploy(  # type: ignore
-            COMPILED_ACCOUNT_CONTRACT, key_pair.public_key
+            COMPILED_ACCOUNT_CONTRACT, key_pair.public_key, token=token
         )
         self.import_account(alias, network_name, contract_address, key_pair.private_key)
         return contract_address
@@ -296,14 +305,15 @@ class BaseStarknetAccount(AccountAPI):
         return contract.deploy(sender=self)
 
     @handle_client_errors
-    def send_transaction(self, txn: TransactionAPI) -> ReceiptAPI:
+    def send_transaction(self, txn: TransactionAPI, token: Optional[str] = None) -> ReceiptAPI:
+        token = token or os.environ.get(ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY)
         if not isinstance(txn, StarknetTransaction):
             # Mostly for mypy
             raise AccountsError("Can only send Starknet transactions.")
 
         account_client = self.create_account_client()
         starknet_txn = txn.as_starknet_object()
-        txn_info = account_client.add_transaction_sync(starknet_txn)
+        txn_info = account_client.add_transaction_sync(starknet_txn, token=token)
         txn_hash = txn_info["transaction_hash"]
         return self.provider.get_transaction(txn_hash)
 

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -306,7 +306,11 @@ class BaseStarknetAccount(AccountAPI):
 
     @handle_client_errors
     def send_transaction(self, txn: TransactionAPI, token: Optional[str] = None) -> ReceiptAPI:
-        token = token or os.environ.get(ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY)
+        if not token and hasattr(txn, "token") and txn.token:  # type: ignore
+            token = txn.token  # type: ignore
+        else:
+            token = os.environ.get(ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY)
+
         if not isinstance(txn, StarknetTransaction):
             # Mostly for mypy
             raise AccountsError("Can only send Starknet transactions.")

--- a/ape_starknet/accounts/_cli.py
+++ b/ape_starknet/accounts/_cli.py
@@ -32,7 +32,8 @@ def accounts():
 @ape_cli_context()
 @click.argument("alias")
 @network_option(ecosystem=PLUGIN_NAME)
-def create(cli_ctx, alias, network):
+@click.option("--token", help="Used for deploying contracts in Alpha MainNet.")
+def create(cli_ctx, alias, network, token):
     """Deploy an account"""
     container = _get_container(cli_ctx)
 
@@ -47,7 +48,7 @@ def create(cli_ctx, alias, network):
                 "first to re-deploy."
             )
 
-    contract_address = container.deploy_account(alias)
+    contract_address = container.deploy_account(alias, token=token)
     contract_address = click.style(contract_address, bold=True)
     cli_ctx.logger.success(f"Account successfully deployed to '{contract_address}'.")
 

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -136,7 +136,10 @@ class Starknet(EcosystemAPI):
         contract = ContractDefinition.deserialize(deployment_bytecode)
         calldata = self.encode_calldata(contract.abi, abi.dict(), args)
         return DeployTransaction(
-            salt=salt, constructor_calldata=calldata, contract_code=contract.dumps()
+            salt=salt,
+            constructor_calldata=calldata,
+            contract_code=contract.dumps(),
+            token=kwargs.get("token"),
         )
 
     def encode_transaction(

--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -202,8 +202,8 @@ class StarknetProvider(SubprocessProvider, ProviderAPI):
     @handle_client_errors
     def send_transaction(self, txn: TransactionAPI, token: Optional[str] = None) -> ReceiptAPI:
         txn = self.prepare_transaction(txn)
-        if not token and hasattr(txn, "token") and txn.token:
-            token = txn.token
+        if not token and hasattr(txn, "token") and txn.token:  # type: ignore
+            token = txn.token  # type: ignore
         else:
             token = os.environ.get(ALPHA_MAINNET_WL_DEPLOY_TOKEN_KEY)
 

--- a/ape_starknet/transactions.py
+++ b/ape_starknet/transactions.py
@@ -52,6 +52,7 @@ class DeployTransaction(StarknetTransaction):
     salt: int
     constructor_calldata: List[int] = []
     caller_address: int = 0
+    token: Optional[str] = None
 
     """Aliases"""
     data: bytes = Field(alias="contract_code")  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "hexbytes>=0.2.2,<0.3",
         "pydantic>=1.9.0,<2.0",
         "ethpm-types>=0.1.1,<0.3.0",
-        "eth-ape>=0.2.1,<0.3.0",
+        "eth-ape>=0.2.2,<0.3.0",
         "pydantic>=1.9.0,<2.0",
         "starknet.py==0.2.2a0",
         "starknet-devnet>=0.1.23",


### PR DESCRIPTION
### What I did

Support for alpha mainnet WL deployment tokens.

**NOTE**: To use the `python` approach to setting the token via the `deploy()` method, it requires this PR https://github.com/ApeWorX/ape/pull/689

### How I did it

Allow token kwarg in places where needed.
Use ENV VAR option
Use `--token` CLI option
Had to fix something in Ape Core

### How to verify it

See README changes! 

* Pass token via python `deploy()`
* Pass token via `--token` in `ape starknet accounts create ACCT --token MYTOKEN`
* Set env var `ALPHA_MAINNET_WL_DEPLOY_TOKEN`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
