### PR TITLE
chore: bump max supported Python version to 3.9

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -16,7 +16,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: |
@@ -37,7 +37,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: |
@@ -53,7 +53,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.7, 3.8]
+                python-version: [3.7, 3.8, 3.9]
 
         steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/title.yaml
+++ b/.github/workflows/title.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,4 @@ repos:
 
 
 default_language_version:
-    python: python3.8
+    python: python3.9

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here
     entry_points={"ape_cli_subcommands": ["ape_starknet=ape_starknet._cli:cli"]},
-    python_requires=">=3.7.2,<3.9",
+    python_requires=">=3.7.2,<3.10",
     extras_require=extras_require,
     py_modules=["ape_starknet"],
     license="Apache-2.0",
@@ -91,5 +91,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
### What I did

Bumped the max Python version.

### How I did it

### How to verify it

- Dependencies installation: OK.
- Tests are green.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
