### PR TITLE
feat: allow to set the passphrase programmatically when importing an …

### DIFF
--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -206,6 +206,7 @@ class StarknetAccountContracts(AccountContainerAPI, StarknetBase):
         network_name: str,
         contract_address: str,
         private_key: Union[int, str],
+        passphrase: Optional[str] = None,
     ):
         if isinstance(private_key, str):
             private_key = private_key.strip("'\"")
@@ -226,7 +227,9 @@ class StarknetAccountContracts(AccountContainerAPI, StarknetBase):
             # Only write keyfile if not in a local network
             path = self.data_folder.joinpath(f"{alias}.json")
             new_account = StarknetKeyfileAccount(key_file_path=path)
-            new_account.write(passphrase=None, private_key=private_key, deployments=deployments)
+            new_account.write(
+                passphrase=passphrase, private_key=private_key, deployments=deployments
+            )
 
         # Add account contract to cache
         address = self.starknet.decode_address(contract_address)

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -40,6 +40,7 @@ from ape_starknet.utils import (
     convert_contract_class_to_contract_type,
     get_chain_id,
     get_random_private_key,
+    pad_hex_str,
 )
 from ape_starknet.utils.basemodel import StarknetBase
 
@@ -212,7 +213,7 @@ class StarknetAccountContracts(AccountContainerAPI, StarknetBase):
         passphrase: Optional[str] = None,
     ):
         if isinstance(private_key, str):
-            private_key = private_key.strip("'\"")
+            private_key = pad_hex_str(private_key.strip("'\""))
             private_key = int(private_key, 16)
 
         network_name = _clean_network_name(network_name)

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -28,7 +28,6 @@ from starknet_py.net.account.compiled_account_contract import (  # type: ignore
 from starknet_py.net.signer.stark_curve_signer import StarkCurveSigner  # type: ignore
 from starknet_py.utils.crypto.facade import ECSignature, sign_calldata  # type: ignore
 from starkware.cairo.lang.vm.cairo_runner import verify_ecdsa_sig  # type: ignore
-from starkware.crypto.signature.signature import get_random_private_key  # type: ignore
 from starkware.crypto.signature.signature import private_to_stark_key  # type: ignore
 from starkware.starknet.core.os.contract_address.contract_address import (  # type: ignore
     calculate_contract_address_from_hash,
@@ -37,7 +36,11 @@ from starkware.starknet.services.api.contract_class import ContractClass  # type
 
 from ape_starknet.tokens import TokenManager
 from ape_starknet.transactions import InvokeFunctionTransaction
-from ape_starknet.utils import convert_contract_class_to_contract_type, get_chain_id
+from ape_starknet.utils import (
+    convert_contract_class_to_contract_type,
+    get_chain_id,
+    get_random_private_key,
+)
 from ape_starknet.utils.basemodel import StarknetBase
 
 APP_KEY_FILE_KEY = "ape-starknet"
@@ -261,7 +264,7 @@ class StarknetAccountContracts(AccountContainerAPI, StarknetBase):
         network_name = self.provider.network.name
         logger.info(f"Deploying an account to '{network_name}' network ...")
 
-        private_key = private_key or get_random_private_key()
+        private_key = private_key or int(get_random_private_key(), 16)
         key_pair = KeyPair.from_private_key(private_key)
 
         account_container = ContractContainer(contract_type=OPEN_ZEPPELIN_ACCOUNT_CONTRACT_TYPE)

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -212,9 +212,11 @@ class StarknetAccountContracts(AccountContainerAPI, StarknetBase):
         private_key: Union[int, str],
         passphrase: Optional[str] = None,
     ):
-        if isinstance(private_key, str):
+        if isinstance(private_key, str) and private_key.startswith("0x"):
             private_key = pad_hex_str(private_key.strip("'\""))
             private_key = int(private_key, 16)
+        elif isinstance(private_key, str):
+            private_key = int(private_key)
 
         network_name = _clean_network_name(network_name)
         key_pair = KeyPair.from_private_key(private_key)
@@ -672,9 +674,9 @@ class StarknetKeyfileAccount(BaseStarknetAccount):
 
     def __encrypt_key_file(self, passphrase: str, private_key: Optional[int] = None) -> Dict:
         private_key = self._get_key(passphrase=passphrase) if private_key is None else private_key
-        key_bytes = HexBytes(private_key)
+        key_str = pad_hex_str(HexBytes(private_key).hex())
         passphrase_bytes = text_if_str(to_bytes, passphrase)
-        return create_keyfile_json(key_bytes, passphrase_bytes, kdf="scrypt")
+        return create_keyfile_json(HexBytes(key_str), passphrase_bytes, kdf="scrypt")
 
     def __decrypt_key_file(self, passphrase: str) -> HexBytes:
         key_file_dict = json.loads(self.key_file_path.read_text())

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -147,7 +147,7 @@ class Starknet(EcosystemAPI, StarknetBase):
             ):
                 pre_encoded_arg = self._pre_encode_value(call_arg)
 
-                if isinstance(pre_encoded_arg, int):
+                if isinstance(pre_encoded_arg, int) and index + 1 < len(call_args):
                     # 'arr_len' was provided.
                     array_index = index + 1
                     pre_encoded_array = self._pre_encode_array(call_args[array_index])

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -140,7 +140,7 @@ class Starknet(EcosystemAPI, StarknetBase):
                 encoded_arg = self._pre_encode_value(call_arg)
                 pre_encoded_args.append(encoded_arg)
             elif (
-                input_type.name in ("arr_len", "call_array_len")
+                input_type.name.endswith("_len")
                 and index < last_index
                 and str(method_abi.inputs[index + 1].type).endswith("*")
             ):

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -128,7 +128,7 @@ class Starknet(EcosystemAPI, StarknetBase):
         transformer = DataTransformer(method_abi.dict(), id_manager)
         pre_encoded_args: List[Any] = []
         index = 0
-        last_index = len(method_abi.inputs) - 1
+        last_index = min(len(method_abi.inputs), len(call_args)) - 1
         did_process_array_during_arr_len = False
 
         for call_arg, input_type in zip(call_args, method_abi.inputs):
@@ -147,7 +147,7 @@ class Starknet(EcosystemAPI, StarknetBase):
             ):
                 pre_encoded_arg = self._pre_encode_value(call_arg)
 
-                if isinstance(pre_encoded_arg, int) and index + 1 < len(call_args):
+                if isinstance(pre_encoded_arg, int):
                     # 'arr_len' was provided.
                     array_index = index + 1
                     pre_encoded_array = self._pre_encode_array(call_args[array_index])

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -140,7 +140,8 @@ class Starknet(EcosystemAPI, StarknetBase):
                 encoded_arg = self._pre_encode_value(call_arg)
                 pre_encoded_args.append(encoded_arg)
             elif (
-                input_type.name.endswith("_len")
+                input_type.name is not None
+                and input_type.name.endswith("_len")
                 and index < last_index
                 and str(method_abi.inputs[index + 1].type).endswith("*")
             ):

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -9,15 +9,15 @@ from eth_utils import is_0x_prefixed
 from ethpm_types import ContractType
 from ethpm_types.abi import ConstructorABI, EventABI, EventABIType, MethodABI
 from hexbytes import HexBytes
-from starknet_py.constants import OZ_PROXY_STORAGE_KEY  # type: ignore
-from starknet_py.net.models.address import parse_address  # type: ignore
-from starknet_py.net.models.chains import StarknetChainId  # type: ignore
-from starknet_py.utils.data_transformer import DataTransformer  # type: ignore
-from starkware.starknet.definitions.fields import ContractAddressSalt  # type: ignore
-from starkware.starknet.definitions.transaction_type import TransactionType  # type: ignore
-from starkware.starknet.public.abi import get_selector_from_name  # type: ignore
-from starkware.starknet.public.abi_structs import identifier_manager_from_abi  # type: ignore
-from starkware.starknet.services.api.contract_class import ContractClass  # type: ignore
+from starknet_py.constants import OZ_PROXY_STORAGE_KEY
+from starknet_py.net.models.address import parse_address
+from starknet_py.net.models.chains import StarknetChainId
+from starknet_py.utils.data_transformer import DataTransformer
+from starkware.starknet.definitions.fields import ContractAddressSalt
+from starkware.starknet.definitions.transaction_type import TransactionType
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.public.abi_structs import identifier_manager_from_abi
+from starkware.starknet.services.api.contract_class import ContractClass
 
 from ape_starknet.exceptions import StarknetEcosystemError
 from ape_starknet.transactions import (

--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -13,16 +13,16 @@ from ape.types import AddressType, BlockID, ContractLog
 from ape.utils import DEFAULT_NUMBER_OF_TEST_ACCOUNTS, cached_property
 from ethpm_types import ContractType
 from ethpm_types.abi import EventABI
-from starknet_py.net import Client as StarknetClient  # type: ignore
-from starknet_py.net.models import parse_address  # type: ignore
-from starkware.starknet.definitions.transaction_type import TransactionType  # type: ignore
-from starkware.starknet.services.api.feeder_gateway.response_objects import (  # type: ignore
+from starknet_py.net import Client as StarknetClient
+from starknet_py.net.models import parse_address
+from starkware.starknet.definitions.transaction_type import TransactionType
+from starkware.starknet.services.api.feeder_gateway.response_objects import (
     DeclareSpecificInfo,
     DeploySpecificInfo,
     InvokeSpecificInfo,
     StarknetBlock,
 )
-from starkware.starkware_utils.error_handling import StarkErrorCode  # type: ignore
+from starkware.starkware_utils.error_handling import StarkErrorCode
 
 from ape_starknet.config import DEFAULT_PORT, StarknetConfig
 from ape_starknet.exceptions import StarknetEcosystemError, StarknetProviderError

--- a/ape_starknet/tokens.py
+++ b/ape_starknet/tokens.py
@@ -4,7 +4,7 @@ from ape.api import Address
 from ape.contracts import ContractInstance
 from ape.exceptions import ContractError
 from ape.types import AddressType
-from starknet_devnet.fee_token import FeeToken  # type: ignore
+from starknet_devnet.fee_token import FeeToken
 
 from ape_starknet.ecosystems import StarknetProxy
 from ape_starknet.utils import convert_contract_class_to_contract_type

--- a/ape_starknet/transactions.py
+++ b/ape_starknet/transactions.py
@@ -9,30 +9,26 @@ from eth_utils import to_int
 from ethpm_types import ContractType, HexBytes
 from ethpm_types.abi import EventABI, MethodABI
 from pydantic import Field, validator
-from starknet_py.constants import TxStatus  # type: ignore
-from starknet_py.net.models.transaction import (  # type: ignore
+from starknet_py.constants import TxStatus
+from starknet_py.net.models.transaction import (
     Declare,
     Deploy,
     InvokeFunction,
     Transaction,
     TransactionType,
 )
-from starkware.starknet.core.os.class_hash import compute_class_hash  # type: ignore
-from starkware.starknet.core.os.contract_address.contract_address import (  # type: ignore
-    calculate_contract_address,
-)
-from starkware.starknet.core.os.transaction_hash.transaction_hash import (  # type: ignore
+from starkware.starknet.core.os.class_hash import compute_class_hash
+from starkware.starknet.core.os.contract_address.contract_address import calculate_contract_address
+from starkware.starknet.core.os.transaction_hash.transaction_hash import (
     TransactionHashPrefix,
     calculate_declare_transaction_hash,
     calculate_deploy_transaction_hash,
     calculate_transaction_hash_common,
 )
-from starkware.starknet.public.abi import get_selector_from_name  # type: ignore
-from starkware.starknet.services.api.contract_class import ContractClass  # type: ignore
-from starkware.starknet.services.api.gateway.transaction import (  # type: ignore
-    DECLARE_SENDER_ADDRESS,
-)
-from starkware.starknet.testing.contract_utils import get_contract_class  # type: ignore
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.services.api.contract_class import ContractClass
+from starkware.starknet.services.api.gateway.transaction import DECLARE_SENDER_ADDRESS
+from starkware.starknet.testing.contract_utils import get_contract_class
 
 from ape_starknet.utils import to_checksum_address
 from ape_starknet.utils.basemodel import StarknetBase

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -187,7 +187,11 @@ def convert_contract_class_to_contract_type(contract_class: ContractClass):
 
 def get_random_private_key() -> str:
     private_key = HexBytes(get_random_pkey()).hex()
-    key = private_key.replace("0x", "")
-    actual_len = len(key)
-    padding = "0" * (64 - actual_len)
-    return f"0x{padding}{key}"
+    return pad_hex_str(private_key)
+
+
+def pad_hex_str(value: str, to_length: int = 66) -> str:
+    val = value.replace("0x", "")
+    actual_len = len(val)
+    padding = "0" * (to_length - 2 - actual_len)
+    return f"0x{padding}{val}"

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -188,13 +188,8 @@ def convert_contract_class_to_contract_type(contract_class: ContractClass):
 
 
 def get_random_private_key() -> str:
-    tries = 0
     private_key = HexBytes(get_random_pkey()).hex()
-    while tries < 10 and len(private_key) != 66:
-        private_key = HexBytes(get_random_pkey()).hex()
-        tries += 1
-
-    if not len(private_key) == 66:
-        raise ValueError(f"Failed to create random private key after '{tries}' attempts.")
-
-    return private_key
+    key = private_key.replace("0x", "")
+    actual_len = len(key)
+    padding = "0" * (64 - actual_len)
+    return f"0x{padding}{key}"

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -16,15 +16,13 @@ from eth_utils import (
 )
 from ethpm_types import ContractType
 from hexbytes import HexBytes
-from starknet_py.net.client import BadRequest  # type: ignore
-from starknet_py.net.models import TransactionType  # type: ignore
-from starknet_py.transaction_exceptions import TransactionRejectedError  # type: ignore
-from starkware.crypto.signature.signature import (
-    get_random_private_key as get_random_pkey,  # type: ignore
-)
-from starkware.starknet.definitions.general_config import StarknetChainId  # type: ignore
-from starkware.starknet.services.api.contract_class import ContractClass  # type: ignore
-from starkware.starknet.services.api.feeder_gateway.response_objects import (  # type: ignore
+from starknet_py.net.client import BadRequest
+from starknet_py.net.models import TransactionType
+from starknet_py.transaction_exceptions import TransactionRejectedError
+from starkware.crypto.signature.signature import get_random_private_key as get_random_pkey
+from starkware.starknet.definitions.general_config import StarknetChainId
+from starkware.starknet.services.api.contract_class import ContractClass
+from starkware.starknet.services.api.feeder_gateway.response_objects import (
     DeclareSpecificInfo,
     DeploySpecificInfo,
     InvokeSpecificInfo,

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -15,9 +15,13 @@ from eth_utils import (
     to_hex,
 )
 from ethpm_types import ContractType
+from hexbytes import HexBytes
 from starknet_py.net.client import BadRequest  # type: ignore
 from starknet_py.net.models import TransactionType  # type: ignore
 from starknet_py.transaction_exceptions import TransactionRejectedError  # type: ignore
+from starkware.crypto.signature.signature import (
+    get_random_private_key as get_random_pkey,  # type: ignore
+)
 from starkware.starknet.definitions.general_config import StarknetChainId  # type: ignore
 from starkware.starknet.services.api.contract_class import ContractClass  # type: ignore
 from starkware.starknet.services.api.feeder_gateway.response_objects import (  # type: ignore
@@ -181,3 +185,16 @@ def convert_contract_class_to_contract_type(contract_class: ContractClass):
             "abi": contract_class.abi,
         }
     )
+
+
+def get_random_private_key() -> str:
+    tries = 0
+    private_key = HexBytes(get_random_pkey()).hex()
+    while tries < 10 and len(private_key) != 66:
+        private_key = HexBytes(get_random_pkey()).hex()
+        tries += 1
+
+    if not len(private_key) == 66:
+        raise ValueError(f"Failed to create random private key after '{tries}' attempts.")
+
+    return private_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
 exclude = "build/"
-ignore_missing_imports = True
+ignore_missing_imports = true
 
 [tool.setuptools_scm]
 write_to = "ape_starknet/version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
 exclude = "build/"
+ignore_missing_imports = True
 
 [tool.setuptools_scm]
 write_to = "ape_starknet/version.py"

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -1,7 +1,7 @@
 import pytest
 from ape.api.networks import LOCAL_NETWORK_NAME
 from eth_utils import remove_0x_prefix
-from starkware.cairo.lang.vm.cairo_runner import pedersen_hash  # type: ignore
+from starkware.cairo.lang.vm.cairo_runner import pedersen_hash
 
 from ape_starknet.utils import get_random_private_key, is_hex_address, to_checksum_address
 

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -1,8 +1,10 @@
 import pytest
+from ape.api.networks import LOCAL_NETWORK_NAME
 from eth_utils import remove_0x_prefix
 from starkware.cairo.lang.vm.cairo_runner import pedersen_hash  # type: ignore
+from starkware.crypto.signature.signature import get_random_private_key  # type: ignore
 
-from ape_starknet.utils import is_hex_address
+from ape_starknet.utils import is_hex_address, to_checksum_address
 
 
 def test_public_keys(existing_key_file_account, public_key):
@@ -53,3 +55,16 @@ def test_access_account_by_str_address(account, account_container, ecosystem, ge
 
 def test_balance(account):
     assert account.balance > 0
+
+
+def test_import_with_passphrase(account_container):
+    alias = "__TEST_IMPORT_WITH_PASSPHRASE__"
+    private_key = get_random_private_key()
+    address = hex(private_key)
+
+    account_container.import_account(
+        alias, LOCAL_NETWORK_NAME, address, private_key, passphrase="p@55W0rd"
+    )
+
+    account = account_container.load(alias)
+    assert account.address == to_checksum_address(address)

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -2,9 +2,8 @@ import pytest
 from ape.api.networks import LOCAL_NETWORK_NAME
 from eth_utils import remove_0x_prefix
 from starkware.cairo.lang.vm.cairo_runner import pedersen_hash  # type: ignore
-from starkware.crypto.signature.signature import get_random_private_key  # type: ignore
 
-from ape_starknet.utils import is_hex_address, to_checksum_address
+from ape_starknet.utils import get_random_private_key, is_hex_address, to_checksum_address
 
 
 def test_public_keys(existing_key_file_account, public_key):

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -58,7 +58,7 @@ def test_balance(account):
 
 def test_import_with_passphrase(account_container):
     alias = "__TEST_IMPORT_WITH_PASSPHRASE__"
-    private_key = get_random_private_key()
+    private_key = int(get_random_private_key(), 16)
     address = hex(private_key)
 
     account_container.import_account(

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -2,7 +2,7 @@ import pytest
 from ape.types import AddressType
 from eth_typing import HexAddress, HexStr
 from hexbytes import HexBytes
-from starkware.starknet.public.abi import get_selector_from_name  # type: ignore
+from starkware.starknet.public.abi import get_selector_from_name
 
 INT_ADDRESS = 14543129564252315649550252856970912276603599239311963926081534426621736121411
 STR_ADDRESS = "0x20271ea04cB854E105d948019Ba1FCdFa61d76D73539700Ff6DD456bcB7bF443"

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -1,7 +1,7 @@
 import time
 
 import pytest
-from starkware.starknet.public.abi import get_selector_from_name  # type: ignore
+from starkware.starknet.public.abi import get_selector_from_name
 
 from ape_starknet.utils import is_checksum_address
 

--- a/tests/functional/test_tokens.py
+++ b/tests/functional/test_tokens.py
@@ -11,7 +11,9 @@ def token_contract(config, account, token_initial_supply, project):
     project_path = Path(__file__).parent.parent / "projects" / "token"
 
     with config.using_project(project_path):
-        yield project.TestToken.deploy(123123, 321321, token_initial_supply, account.address)
+        yield project.get_contract("TestToken").deploy(
+            123123, 321321, token_initial_supply, account.address
+        )
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +21,7 @@ def proxy_token_contract(config, account, token_initial_supply, token_contract, 
     project_path = Path(__file__).parent.parent / "projects" / "proxy"
 
     with config.using_project(project_path):
-        return project.Proxy.deploy(token_contract.address)
+        return project.get_contract("Proxy").deploy(token_contract.address)
 
 
 @pytest.fixture(scope="module")

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,0 +1,13 @@
+import pytest
+from hexbytes import HexBytes
+
+from ape_starknet.utils import get_random_private_key
+
+
+@pytest.mark.parametrize("iteration", range(10))
+def test_get_random_private_key(iteration):
+    pkey = get_random_private_key()
+    assert len(pkey) == 66
+    pkey_int = int(pkey, 16)
+    pkey_back_to_str = HexBytes(pkey_int).hex()
+    assert pkey_back_to_str == pkey

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -10,4 +10,4 @@ def test_get_random_private_key(iteration):
     assert len(pkey) == 66
     pkey_int = int(pkey, 16)
     pkey_back_to_str = HexBytes(pkey_int).hex()
-    assert pkey_back_to_str == pkey
+    assert pkey_back_to_str.replace("0x", "") in pkey

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,7 +20,11 @@ class ApeStarknetCliRunner:
     def invoke(
         self, *cmd, input: Optional[Union[str, List[str]]] = None, ensure_successful: bool = True
     ):
-        input_str = "\n".join(input) if isinstance(input, (list, tuple)) else (input or "")
+        if isinstance(input, (list, tuple)):
+            input_str = "\n".join([str(i) for i in input])
+        else:
+            input_str = input or ""
+
         ape_cmd = self._get_cmd(*cmd)
         catch_exceptions = not ensure_successful
         result = self.runner.invoke(

--- a/tests/integration/test_accounts.py
+++ b/tests/integration/test_accounts.py
@@ -87,7 +87,15 @@ def test_delete(accounts_runner, existing_key_file_account):
     )
 
 
-def test_import(accounts_runner, existing_key_file_account, account_container):
+@pytest.mark.parametrize(
+    "private_key",
+    (
+        get_random_private_key(),
+        "0x0097a6a4998e2eb47d4cea623c9f8b3048764fc38a92616bdf1c3e68be8b5e28",
+        267944034277627769235577208827196223019601239705086925741947749358138777128,
+    ),
+)
+def test_import(accounts_runner, existing_key_file_account, account_container, private_key):
     network = "starknet:testnet"  # NOTE: Does not actually connect
     account_path = account_container.data_folder / f"{EXISTING_KEY_FILE_ALIAS}.json"
     address = existing_key_file_account.address
@@ -96,7 +104,6 @@ def test_import(accounts_runner, existing_key_file_account, account_container):
         # Corrupted from previous test
         account_path.unlink()
 
-    private_key = get_random_private_key()
     accounts_runner.invoke(
         "import",
         EXISTING_KEY_FILE_ALIAS,

--- a/tests/integration/test_accounts.py
+++ b/tests/integration/test_accounts.py
@@ -4,8 +4,8 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from hexbytes import HexBytes
-from starkware.crypto.signature.signature import get_random_private_key  # type: ignore
+
+from ape_starknet.utils import get_random_private_key
 
 from ..conftest import CONTRACT_ADDRESS, EXISTING_KEY_FILE_ALIAS, PASSWORD
 from .conftest import ApeStarknetCliRunner
@@ -96,7 +96,7 @@ def test_import(accounts_runner, existing_key_file_account, account_container):
         # Corrupted from previous test
         account_path.unlink()
 
-    private_key = HexBytes(get_random_private_key()).hex()
+    private_key = get_random_private_key()
     accounts_runner.invoke(
         "import",
         EXISTING_KEY_FILE_ALIAS,


### PR DESCRIPTION
…account

### What I did

I added the capability to use `import_account()` without prompting the user. That is useful when automating deployment via a CI, or when we do not want to bother with prompt at all.

### How I did it

I added a kyword-argument to pass the passphrase.

### How to verify it

A test was added to ensure changes are working as expected. And the default behavior was not modified.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
