### PR TITLE
fix: prevent double TX return data decoding

### DIFF
--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -220,8 +220,7 @@ class StarknetProvider(SubprocessProvider, ProviderAPI, StarknetBase):
             raise ProviderNotConnectedError()
 
         starknet_obj = txn.as_starknet_object()
-        return_value = self.client.call_contract_sync(starknet_obj)
-        return self.starknet.decode_returndata(txn.method_abi, return_value)  # type: ignore
+        return self.client.call_contract_sync(starknet_obj)  # type: ignore
 
     @handle_client_errors
     def get_transaction(self, txn_hash: str) -> ReceiptAPI:


### PR DESCRIPTION
### What I did

Invoke TX return data is currently decode twice. The first time is there: https://github.com/ApeWorX/ape/blob/846a3fbbd26afc2364d41efc62037997ed1bf98d/src/ape/contracts/base.py#L82-L86.

### How I did it

I simply removed the plugin-specific code.

### How to verify it

Tests pass.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
