### PR TITLE
fix: make TX return data decoding more reliable

### DIFF
--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -393,6 +393,7 @@ class BaseStarknetAccount(AccountAPI, StarknetBase):
         )
         txn.receiver = self.address
         txn.sender = None
+        txn.original_method_abi = txn.method_abi
         txn.method_abi = execute_abi
         txn.signature = self.sign_transaction(txn)
         return txn

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -100,13 +100,6 @@ class Starknet(EcosystemAPI, StarknetBase):
         iter_data = iter(raw_data)
         decoded: List[Any] = []
 
-        # Given that the caller is StarkNetProvider.send_transaction().
-        # In the caller, we removed the first item which was the total items when
-        # a sender is specified to the invoke TX.
-        # Now, we are dealing with a 1-item array, it's safe to simply return it.
-        if len(raw_data) == 1:
-            return raw_data[0]
-
         for abi_output_cur, abi_output_next in zip_longest(abi.outputs, abi.outputs[1:]):
             if abi_output_cur.type == "Uint256":
                 # Unint256 are stored using 2 slots

--- a/ape_starknet/transactions.py
+++ b/ape_starknet/transactions.py
@@ -152,6 +152,12 @@ class InvokeFunctionTransaction(StarknetTransaction):
     sender: Optional[AddressType] = None
     type: TransactionType = TransactionType.INVOKE_FUNCTION
 
+    """
+    Only set when invoked from an account `__execute__`
+    special method to help decoding return data
+    """
+    original_method_abi: Optional[MethodABI] = None
+
     """Aliases"""
     data: List[Any] = Field(alias="calldata")  # type: ignore
     receiver: AddressType = Field(alias="contract_address")

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -144,10 +144,49 @@ def test_external_call_array_outputs(contract, account):
     assert receipt.return_value == [1, 2, 3]
 
 
+def test_external_call_felt_outputs_from_account(contract, account):
+    receipt = contract.get_felt(sender=account)
+    assert receipt.returndata == ["0x1", "0x2"]
+    assert receipt.return_value == 2
+
+
 def test_external_call_array_outputs_from_account(contract, account):
     receipt = contract.get_array(sender=account)
     assert receipt.returndata == ["0x4", "0x3", "0x1", "0x2", "0x3"]
     assert receipt.return_value == [1, 2, 3]
+
+
+def test_external_call_uint256_outputs_from_account(contract, account):
+    receipt = contract.get_uint256(sender=account)
+    assert receipt.returndata == ["0x2", "0x1", "0x0"]
+    assert receipt.return_value == (1, 0)
+
+
+def test_external_call_uint256s_outputs_from_account(contract, account):
+    receipt = contract.get_uint256s(sender=account)
+    assert receipt.returndata == ["0x6", "0x7b", "0x0", "0x0", "0x7b", "0x84", "0x7b"]
+    assert receipt.return_value == [(123, 0), (0, 123), (132, 123)]
+
+
+def test_external_call_mixed_outputs_from_account(contract, account):
+    receipt = contract.get_mix(sender=account)
+    assert receipt.returndata == [
+        "0xd",
+        "0x1",
+        "0x2",
+        "0x3",
+        "0x4",
+        "0x5",
+        "0x6",
+        "0x3",
+        "0x8",
+        "0x9",
+        "0xa",
+        "0xb",
+        "0xc",
+        "0xd",
+    ]
+    assert receipt.return_value == [1, [3, 4], (5, 6), [8, 9, 10], 11, (12, 13)]
 
 
 def test_view_call_array_outputs(contract, account):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -67,17 +67,6 @@ def test_decode_logs(ecosystem, event_abi, raw_logs):
             [1, 1],
             [1],
         ),
-        # Mimic a call made via account.__execute__()
-        (
-            CustomABI(
-                outputs=[
-                    EventABIType(name="response_len", type="felt"),
-                    EventABIType(name="response", type="felt*"),
-                ],
-            ),
-            [42],
-            42,
-        ),
         # More than 2 arguments, but no array in there
         (
             CustomABI(

--- a/tests/projects/project/contracts/MyContract.cairo
+++ b/tests/projects/project/contracts/MyContract.cairo
@@ -7,6 +7,7 @@ from starkware.cairo.common.hash import hash2
 from starkware.cairo.common.signature import (
     verify_ecdsa_signature)
 from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256
 from starkware.starknet.common.syscalls import get_caller_address
 
 @storage_var
@@ -90,6 +91,71 @@ func get_array{
     let (current_count) = array_get_counter.read()
     array_get_counter.write(current_count + 1)
     return (ARRAY_SIZE, ptr)
+end
+
+@external
+func get_felt{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res: felt):
+    return (res=2)
+end
+
+@external
+func get_mix{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (
+            start: felt,
+            arr_len: felt,
+            arr: felt*,
+            some_uint256: Uint256,
+            arr2_len: felt,
+            arr2: felt*,
+            suffix: felt,
+            last_uint256: Uint256,
+        ):
+    alloc_locals
+
+    let (local arr : felt*) = alloc()
+    assert arr[0] = 3
+    assert arr[1] = 4
+
+    let some_uint256 = Uint256(5, 6)
+
+    let (local arr2 : felt*) = alloc()
+    assert arr2[0] = 8
+    assert arr2[1] = 9
+    assert arr2[2] = 10
+
+    let last_uint256 = Uint256(12, 13)
+
+    return (
+        start=1,
+        arr_len=2,
+        arr=arr,
+        some_uint256=some_uint256,
+        arr2_len=3,
+        arr2=arr2,
+        suffix=11,
+        last_uint256=last_uint256
+    )
+end
+
+@external
+func get_uint256{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res: Uint256):
+    let res = Uint256(1, 0)
+    return (res=res)
+end
+
+@external
+func get_uint256s{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res1: Uint256, res2: Uint256, res3: Uint256):
+    let res1 = Uint256(123, 0)
+    let res2 = Uint256(0, 123)
+    let res3 = Uint256(132, 123)
+    return (res1=res1, res2=res2, res3=res3)
 end
 
 @external


### PR DESCRIPTION
### What I did

When running the latest version (0.3.0a1) on our SithSwap tests suit, we discovered number of problems with account-specific transaction return data decoding.

### How I did it

I needed the original ABI to decode return data because it was shadowed by the execute special ABI. Trying to guess what was the expected result was working for simple elements, but as soon as a Uint256 was in the loop, it was breaking everything.

So I saved the original ABI into a specific TX attribute, and use it just at the decoding step.

### How to verify it

- Tested in our tests suit with success.
- Tests added.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
