### PR TITLE
feat: allow unlocking and auto-signing from keyfile accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ ape starknet accounts delete <ALIAS> --network starknet:testnet
 
 **NOTE**: You don't have to specify the network if your account is only deployed to a single network.
 
+#### Auto-Sign Message
+
+While generally bad practice, sometimes it is necessary to have unlocked keyfile accounts auto-signing messages.
+An example would be during testnet automated deployments.
+To achieve this, use the ``set_autosign()`` method available on the keyfile accounts:
+
+```python
+import keyring
+from ape import accounts
+
+# Use keyring package to store secrets
+password = keyring.get_password("starknet-testnet-automations", "ci-shared-account")
+testnet_account = accounts.load("starknet-testnet-account")
+testnet_account.set_autosign(True, passphrase=password)
+
+# Won't prompt for signing or unlocking
+testnet_account.sign_message([123])
+```
+
 ### Declare and Deploy Contracts
 
 In Starknet, you can declare contract types by publishing them to the chain.

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -651,12 +651,20 @@ class StarknetKeyfileAccount(BaseStarknetAccount):
         self.locked = False
 
     def set_autosign(self, enabled: bool, passphrase: Optional[str] = None):
-        self.unlock(passphrase=passphrase)
+        locked_at_start = self.locked
 
-        if enabled:
-            logger.warning("Danger! This account will now sign any transaction its given.")
+        try:
+            if locked_at_start:
+                self.unlock(passphrase=passphrase)
 
-        self.__autosign = enabled
+            if enabled:
+                logger.warning("Danger! This account will now sign any transaction its given.")
+
+            self.__autosign = enabled
+        finally:
+            self.locked = locked_at_start
+            if locked_at_start:
+                self.__cached_key = None
 
     def _get_key(self, passphrase: Optional[str] = None) -> int:
         if self.__cached_key is not None:

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -651,20 +651,15 @@ class StarknetKeyfileAccount(BaseStarknetAccount):
         self.locked = False
 
     def set_autosign(self, enabled: bool, passphrase: Optional[str] = None):
-        locked_at_start = self.locked
+        if enabled:
+            self.unlock(passphrase=passphrase)
+            logger.warning("Danger! This account will now sign any transaction its given.")
 
-        try:
-            if locked_at_start:
-                self.unlock(passphrase=passphrase)
-
-            if enabled:
-                logger.warning("Danger! This account will now sign any transaction its given.")
-
-            self.__autosign = enabled
-        finally:
-            self.locked = locked_at_start
-            if locked_at_start:
-                self.__cached_key = None
+        self.__autosign = enabled
+        if not enabled:
+            # Re-lock if was turning off
+            self.locked = True
+            self.__cached_key = None
 
     def _get_key(self, passphrase: Optional[str] = None) -> int:
         if self.__cached_key is not None:

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -124,38 +124,23 @@ def test_unlock_from_prompt_and_sign_transaction(isolation, devnet_keyfile_accou
         contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
 
 
-def test_use_autosign(isolation, devnet_keyfile_account, contract):
+def test_set_autosign(isolation, devnet_keyfile_account, contract):
     with isolation(input="123\n"):
         devnet_keyfile_account.set_autosign(True)
 
-    with isolation(input="123\n"):
-        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
-
-    # Disable and verify we have to sign again
-    devnet_keyfile_account.set_autosign(False)
-    with isolation(input="123\ny\n"):
-        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
-
-
-def test_use_autosign_and_provide_passphrase(isolation, devnet_keyfile_account, contract):
-    devnet_keyfile_account.set_autosign(True, passphrase="123")
-
-    with isolation(input="123\n"):
-        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
-
-    # Disable and verify we have to sign again
-    devnet_keyfile_account.set_autosign(False)
-    with isolation(input="123\ny\n"):
-        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
-
-
-def test_use_autosign_on_unlocked_account(isolation, devnet_keyfile_account, contract):
-    devnet_keyfile_account.unlock(passphrase="123")
-    devnet_keyfile_account.set_autosign(True)
     contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
 
-    # Turn off autosign
+    # Disable and verify we have to sign again
     devnet_keyfile_account.set_autosign(False)
+    with isolation(input="123\ny\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
 
-    with isolation(input="y\n"):
+
+def test_set_autosign_and_provide_passphrase(isolation, devnet_keyfile_account, contract):
+    devnet_keyfile_account.set_autosign(True, passphrase="123")
+    contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+    # Disable and verify we have to sign again
+    devnet_keyfile_account.set_autosign(False)
+    with isolation(input="123\ny\n"):
         contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -74,3 +74,20 @@ def test_transfer(account, second_account):
     initial_balance = second_account.balance
     account.transfer(second_account, 10)
     assert second_account.balance == initial_balance + 10
+
+
+def test_use_unlocked_keyfile_account(account, account_container, contract):
+    # Copy normal dev account as a keyfile account
+    account_container.import_account(
+        "__DEV_AS_KEYFILE_ACCOUNT__",
+        "testnet",
+        account.address,
+        private_key=account.private_key,
+        passphrase="123",
+    )
+    new_account = account_container.load("__DEV_AS_KEYFILE_ACCOUNT__")
+    new_account.unlock("123")
+    new_account.set_autosign(True)
+
+    # Should not prompt!
+    assert contract.get_array(sender=new_account)

--- a/tests/functional/test_accounts.py
+++ b/tests/functional/test_accounts.py
@@ -113,7 +113,7 @@ def test_unlock_with_passphrase_and_sign_transaction(isolation, devnet_keyfile_a
     devnet_keyfile_account.unlock(passphrase="123")
 
     with isolation(input="y\n"):
-        contract.increase_balance(100, sender=devnet_keyfile_account)
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
 
 
 def test_unlock_from_prompt_and_sign_transaction(isolation, devnet_keyfile_account, contract):
@@ -121,10 +121,41 @@ def test_unlock_from_prompt_and_sign_transaction(isolation, devnet_keyfile_accou
         devnet_keyfile_account.unlock()
 
     with isolation(input="y\n"):
-        contract.increase_balance(100, sender=devnet_keyfile_account)
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
 
 
-def test_use_autosign(devnet_keyfile_account, contract):
-    # No prompts should occur!
+def test_use_autosign(isolation, devnet_keyfile_account, contract):
+    with isolation(input="123\n"):
+        devnet_keyfile_account.set_autosign(True)
+
+    with isolation(input="123\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+    # Disable and verify we have to sign again
+    devnet_keyfile_account.set_autosign(False)
+    with isolation(input="123\ny\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+
+def test_use_autosign_and_provide_passphrase(isolation, devnet_keyfile_account, contract):
     devnet_keyfile_account.set_autosign(True, passphrase="123")
+
+    with isolation(input="123\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+    # Disable and verify we have to sign again
+    devnet_keyfile_account.set_autosign(False)
+    with isolation(input="123\ny\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+
+def test_use_autosign_on_unlocked_account(isolation, devnet_keyfile_account, contract):
+    devnet_keyfile_account.unlock(passphrase="123")
+    devnet_keyfile_account.set_autosign(True)
     contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)
+
+    # Turn off autosign
+    devnet_keyfile_account.set_autosign(False)
+
+    with isolation(input="y\n"):
+        contract.increase_balance(devnet_keyfile_account, 100, sender=devnet_keyfile_account)


### PR DESCRIPTION
### What I did

Allow using keyfile accounts in a script by programmatically supporting unlocking and setting autosign

### How I did it

copied from Ethereum ape-accounts core plugin

### How to verify it

```
account = accounts.load("argentx")
account.unlock("123")
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
