### PR TITLE
test: prove can deploy to eth mid test

### DIFF
--- a/tests/functional/test_networks.py
+++ b/tests/functional/test_networks.py
@@ -1,0 +1,15 @@
+import pytest
+from ape.contracts import ContractInstance
+
+
+@pytest.fixture
+def ethereum_account(accounts):
+    return accounts.test_accounts[0]
+
+
+def test_multiple_networks_in_test(provider, networks, project, ethereum_account):
+    assert provider.chain_id == 1536727068981429685321
+
+    with networks.ethereum.local.use_provider("test"):
+        eth_contract = project.EthContract.deploy(sender=ethereum_account)
+        assert isinstance(eth_contract, ContractInstance)

--- a/tests/projects/project/contracts/ethereum/EthContract.json
+++ b/tests/projects/project/contracts/ethereum/EthContract.json
@@ -1,0 +1,3 @@
+[
+    {"name":"foo","type":"fallback", "stateMutability":"nonpayable"}
+]


### PR DESCRIPTION
### What I did

fixes: #61 
Shows that we can connect to Ethereum in the middle of a test.

### How I did it

using the networks context manager.

### How to verify it

** Tell me what to add to the test to reproduce the failures you are seeing!**

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
