### PR TITLE
fix: handle Uint256 array in TX return data decoder

### DIFF
--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -114,13 +114,11 @@ class Starknet(EcosystemAPI, StarknetBase):
                 # Array - strip off leading length
                 array_len = next(iter_data)
                 if abi_output_next.type == "felt*":
-                    decoded.append([next(iter_data) for _ in range(array_len)])  # type: ignore
+                    decoded.append([next(iter_data) for _ in range(array_len)])
                 elif abi_output_next.type == "Uint256*":
                     # Unint256 are stored using 2 slots
                     array_len = array_len // 2
-                    decoded.append(
-                        [(next(iter_data), next(iter_data)) for _ in range(array_len)]
-                    )  # type: ignore
+                    decoded.append([(next(iter_data), next(iter_data)) for _ in range(array_len)])
             elif str(abi_output_cur.type).endswith("*"):
                 # The array was handled by the previous condition at the previous iteration
                 continue

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -109,7 +109,7 @@ class Starknet(EcosystemAPI, StarknetBase):
             elif (
                 abi_output_cur.type == "felt"
                 and abi_output_next
-                and abi_output_next.type.endswith("*")
+                and str(abi_output_next.type).endswith("*")
             ):
                 # Array - strip off leading length
                 array_len = next(iter_data)
@@ -118,15 +118,19 @@ class Starknet(EcosystemAPI, StarknetBase):
                 elif abi_output_next.type == "Uint256*":
                     # Unint256 are stored using 2 slots
                     array_len = array_len // 2
-                    decoded.append([(next(iter_data), next(iter_data)) for _ in range(array_len)])  # type: ignore
-            elif abi_output_cur.type.endswith("*"):
+                    decoded.append(
+                        [(next(iter_data), next(iter_data)) for _ in range(array_len)]
+                    )  # type: ignore
+            elif str(abi_output_cur.type).endswith("*"):
                 # The array was handled by the previous condition at the previous iteration
                 continue
             else:
                 decoded.append(next(iter_data))
 
         # Keep only the expected data instead of a 1-item array
-        if len(abi.outputs) == 1 or (len(abi.outputs) == 2 and abi.outputs[1].type.endswith("*")):
+        if len(abi.outputs) == 1 or (
+            len(abi.outputs) == 2 and str(abi.outputs[1].type).endswith("*")
+        ):
             decoded = decoded[0]
 
         return decoded

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -114,6 +114,28 @@ def test_decode_logs(ecosystem, event_abi, raw_logs):
             [1, 0],
             (1, 0),
         ),
+        # 1-item array of Uint256
+        (
+            CustomABI(
+                outputs=[
+                    EventABIType(name="amounts_len", type="felt"),
+                    EventABIType(name="amounts", type="Uint256*"),
+                ],
+            ),
+            [2, 123, 0],
+            [(123, 0)],
+        ),
+        # An array of Uint256
+        (
+            CustomABI(
+                outputs=[
+                    EventABIType(name="amounts_len", type="felt"),
+                    EventABIType(name="amounts", type="Uint256*"),
+                ]
+            ),
+            [6, 123, 0, 0, 123, 123, 123],
+            [(123, 0), (0, 123), (123, 123)],
+        ),
         # Mix: more than 2 arguments, several arrays, and Uint256
         (
             CustomABI(


### PR DESCRIPTION
### What I did

A function returning an array of Uint256 values is now properly handled.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
