### PR TITLE
fix: fix for TX return data decoder with Uint256s array

### DIFF
--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -117,7 +117,6 @@ class Starknet(EcosystemAPI, StarknetBase):
                     decoded.append([next(iter_data) for _ in range(array_len)])
                 elif abi_output_next.type == "Uint256*":
                     # Unint256 are stored using 2 slots
-                    array_len = array_len // 2
                     decoded.append([(next(iter_data), next(iter_data)) for _ in range(array_len)])
             elif str(abi_output_cur.type).endswith("*"):
                 # The array was handled by the previous condition at the previous iteration

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -168,6 +168,12 @@ def test_external_call_uint256s_outputs_from_account(contract, account):
     assert receipt.return_value == [(123, 0), (0, 123), (132, 123)]
 
 
+def test_external_call_uint256s_array_outputs_from_account(contract, account):
+    receipt = contract.get_uint256s_array(sender=account)
+    assert receipt.returndata == ["0x7", "0x3", "0x7b", "0x0", "0x0", "0x7b", "0x84", "0x7b"]
+    assert receipt.return_value == [(123, 0), (0, 123), (132, 123)]
+
+
 def test_external_call_mixed_outputs_from_account(contract, account):
     receipt = contract.get_mix(sender=account)
     assert receipt.returndata == [
@@ -192,6 +198,11 @@ def test_external_call_mixed_outputs_from_account(contract, account):
 def test_view_call_array_outputs(contract, account):
     array = contract.view_array()
     assert array == [1, 2, 3]
+
+
+def test_view_call_uint256s_array_outputs(contract):
+    array = contract.view_uint256s_array()
+    assert array == [(123, 0), (0, 123), (132, 123)]
 
 
 def test_unable_to_afford_transaction(contract, account, provider):

--- a/tests/functional/test_ecosystem.py
+++ b/tests/functional/test_ecosystem.py
@@ -122,7 +122,7 @@ def test_decode_logs(ecosystem, event_abi, raw_logs):
                     EventABIType(name="amounts", type="Uint256*"),
                 ],
             ),
-            [2, 123, 0],
+            [1, 123, 0],
             [(123, 0)],
         ),
         # An array of Uint256
@@ -133,7 +133,7 @@ def test_decode_logs(ecosystem, event_abi, raw_logs):
                     EventABIType(name="amounts", type="Uint256*"),
                 ]
             ),
-            [6, 123, 0, 0, 123, 123, 123],
+            [3, 123, 0, 0, 123, 123, 123],
             [(123, 0), (0, 123), (123, 123)],
         ),
         # Mix: more than 2 arguments, several arrays, and Uint256

--- a/tests/projects/project/contracts/MyContract.cairo
+++ b/tests/projects/project/contracts/MyContract.cairo
@@ -159,6 +159,18 @@ func get_uint256s{
 end
 
 @external
+func get_uint256s_array{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (amounts_len: felt, amounts: Uint256*):
+    alloc_locals
+    let (local amounts : Uint256*) = alloc()
+    assert amounts[0] = Uint256(123, 0)
+    assert amounts[1] = Uint256(0, 123)
+    assert amounts[2] = Uint256(132, 123)
+    return (amounts_len=3, amounts=amounts)
+end
+
+@external
 func get_caller{
         syscall_ptr: felt*,
         pedersen_ptr: HashBuiltin*,
@@ -196,6 +208,18 @@ func get_last_sum{
         range_check_ptr}() -> (res : felt):
     let (res) = last_sum.read()
     return (res)
+end
+
+@view
+func view_uint256s_array{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (amounts_len: felt, amounts: Uint256*):
+    alloc_locals
+    let (local amounts : Uint256*) = alloc()
+    assert amounts[0] = Uint256(123, 0)
+    assert amounts[1] = Uint256(0, 123)
+    assert amounts[2] = Uint256(132, 123)
+    return (amounts_len=3, amounts=amounts)
 end
 
 # Increases the balance of the given user by the given amount.


### PR DESCRIPTION
The original fix was partly correct, here is the final one.

### What I did

My last fix from #64 was partially incorrect. I assumed an Uint256s array would have an array length of `N * Uint256.SIZE`, but in fact it's simply `N`.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
