### PR TITLE
fix: improve conversion check to prevent ecosystem mix

### DIFF
--- a/ape_starknet/conversion.py
+++ b/ape_starknet/conversion.py
@@ -3,7 +3,7 @@ from typing import Any
 from ape.api import ConverterAPI
 from ape.types import AddressType
 
-from ape_starknet.utils import is_checksum_address, is_hex_address, to_checksum_address
+from ape_starknet.utils import PLUGIN_NAME, is_checksum_address, is_hex_address, to_checksum_address
 
 
 # NOTE: This utility converter ensures that all bytes args can accept hex too
@@ -13,7 +13,12 @@ class StarknetAddressConverter(ConverterAPI):
     """
 
     def is_convertible(self, value: Any) -> bool:
-        return isinstance(value, str) and is_hex_address(value) and not is_checksum_address(value)
+        return (
+            self.provider.network.ecosystem.name == PLUGIN_NAME
+            and isinstance(value, str)
+            and is_hex_address(value)
+            and not is_checksum_address(value)
+        )
 
     def convert(self, value: str) -> AddressType:
         """


### PR DESCRIPTION
### What I did

Tricky scenario:
- install `ape-starknet==0.3.0a2`, and `ape-hardhat==0.3.0`
- run tests on Solidity contracts
- see all failures of the same kind:
  ```python
  eth_abi.exceptions.EncodingTypeError: Value `'0x00000000000000...` of type <class 'str'> cannot be encoded by AddressEncoder`
  ```

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
