### PR TITLE
fix: skip traces for non-invoke TXs

### DIFF
--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -16,6 +16,7 @@ from ethpm_types.abi import EventABI
 from starknet_py.net.client_models import (
     BlockSingleTransactionTrace,
     ContractCode,
+    InvokeTransaction,
     SentTransactionResponse,
     StarknetBlock,
 )
@@ -247,8 +248,13 @@ class StarknetProvider(SubprocessProvider, ProviderAPI, StarknetBase):
         self.starknet_client.wait_for_tx_sync(txn_hash)
         txn_info = self.starknet_client.get_transaction_sync(tx_hash=txn_hash)
         receipt = self.starknet_client.get_transaction_receipt_sync(tx_hash=txn_hash)
-        trace = self._get_single_trace(receipt.block_number, receipt.hash)
-        trace_data = trace.function_invocation if trace else {}
+
+        if isinstance(txn_info, InvokeTransaction):
+            trace = self._get_single_trace(receipt.block_number, receipt.hash)
+            trace_data = trace.function_invocation if trace else {}
+        else:
+            trace_data = {}
+
         receipt_dict: Dict[str, Any] = {"provider": self, **trace_data, **vars(receipt)}
         receipt_dict = get_dict_from_tx_info(txn_info, **receipt_dict)
         return self.starknet.decode_receipt(receipt_dict)

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -23,7 +23,6 @@ def test_deploy(project):
     assert deployment
 
 
-@pytest.mark.xfail(reason="https://github.com/Shard-Labs/starknet-devnet/issues/194")
 def test_declare_then_deploy(account, chain, project, provider, factory_contract_container):
     # Declare contract type. The result should contain a 'class_hash'.
     declaration = provider.declare(project.MyContract)


### PR DESCRIPTION
### What I did

Good side-effect: it prevents hitting https://github.com/Shard-Labs/starknet-devnet/issues/194.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
