### PR TITLE
fix: properly handle TX return data once for all

### DIFF
--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -96,7 +96,15 @@ def extract_trace_data(trace: BlockSingleTransactionTrace) -> Dict[str, Any]:
 
     trace_data = trace.function_invocation
 
-    # Keep the most revelant result
+    # Keep the most relevant `result`: given the account implementation, `result`
+    # may contain an additional number prepend to the data to expose the total
+    # number of items. For a method returning a 3-items array like `[1, 2, 3]`,
+    # in such scenario `results` would be `[0x4, 0x3, 0x1, 0x2, 0x3]` (the prepend
+    # number: 4, the array length: 3, then array items: 1, 2, and 3).
+    # As there is no known way to guess when to remove such a number, we prefer to "scan"
+    # trace internals to select the most appropriate result. For instance, when `result`
+    # contains the additional value, we just need to use the "internal call" `result`
+    # that will contain the exact value the method returned.
     invokation_result = trace_data["result"]
     internal_calls = trace_data["internal_calls"]
     trace_data["result"] = (

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -13,6 +13,7 @@ from ethpm_types.abi import EventABI
 from hexbytes import HexBytes
 from starknet_py.net.client_errors import ClientError
 from starknet_py.net.client_models import (
+    BlockSingleTransactionTrace,
     DeclareTransaction,
     DeployTransaction,
     InvokeTransaction,
@@ -87,6 +88,22 @@ def is_checksum_address(value: Any) -> bool:
         return False
 
     return value == to_checksum_address(value)
+
+
+def extract_trace_data(trace: BlockSingleTransactionTrace) -> Dict[str, Any]:
+    if not trace:
+        return {}
+
+    trace_data = trace.function_invocation
+
+    # Keep the most revelant result
+    invokation_result = trace_data["result"]
+    internal_calls = trace_data["internal_calls"]
+    trace_data["result"] = (
+        internal_calls[-1]["result"] if internal_calls else invokation_result
+    ) or invokation_result
+
+    return trace_data
 
 
 def handle_client_errors(f):

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ extras_require = {
         "ape-cairo>=0.4.0a0",  # For compiling contracts in tests
     ],
     "lint": [
-        "black>=22.6.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.971,<1.0",  # Static type analyzer
+        "black>=22.6.0",  # auto-formatter and linter
+        "mypy>=0.971",  # Static type analyzer
         "types-requests",  # NOTE: Needed due to mypy typeshed
-        "flake8>=4.0.1,<5.0",  # Style linter
-        "isort>=5.10.1,<6.0",  # Import sorting linter
+        "flake8>=4.0.1",  # Style linter
+        "isort>=5.10.1",  # Import sorting linter
         "types-pkg-resources>=0.1.3,<0.2",
     ],
     "release": [  # `release` GitHub Action job uses this
@@ -64,7 +64,7 @@ setup(
         "eth-ape>=0.4.0,<0.5",
         "ethpm-types>=0.3.3,<0.4",
         "starknet.py>=0.4.4a0,<0.5",
-        "starknet-devnet>=0.2.6,<0.3",
+        "starknet-devnet==0.2.6",
         "importlib-metadata ; python_version<'3.8'",
     ],
     entry_points={"ape_cli_subcommands": ["ape_starknet=ape_starknet._cli:cli"]},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -328,3 +328,20 @@ def key_file_account(config, key_file_account_data):
 @pytest.fixture(scope="session")
 def token_initial_supply():
     return TOKEN_INITIAL_SUPPLY
+
+
+@pytest.fixture(scope="session")
+def data_folder():
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture(scope="session")
+def traces_testnet_243810(data_folder):
+    content = (data_folder / "traces-testnet-block-243810.json").read_text()
+    return json.loads(content)["traces"]
+
+
+@pytest.fixture(scope="session")
+def traces_testnet_243810_results(data_folder):
+    content = (data_folder / "traces-testnet-block-243810_results.json").read_text()
+    return json.loads(content)

--- a/tests/data/traces-testnet-block-243810.json
+++ b/tests/data/traces-testnet-block-243810.json
@@ -1,0 +1,11677 @@
+{
+    "traces": [
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x35",
+                    "0x35",
+                    "0xd",
+                    "0x6274632f757364",
+                    "0x411cbb7c60cb7800000",
+                    "0x62ade0a2",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x6574682f757364",
+                    "0x36431c48afc7000000",
+                    "0x62ade0bf",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x6c756e612f757364",
+                    "0x31feb352c400",
+                    "0x62ade094",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x736f6c2f757364",
+                    "0x1a38688d5a80f0000",
+                    "0x62ade0c0",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x617661782f757364",
+                    "0xd26323adcaec0000",
+                    "0x62ade0c7",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x646f67652f757364",
+                    "0xc0e33222ca5000",
+                    "0x62ade057",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x736869622f757364",
+                    "0x731b0bd7c00",
+                    "0x62ade05b",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x74656d702f757364",
+                    "0x7d78d3108de804",
+                    "0x62ade0cf",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x6461692f757364",
+                    "0xde7d1b0f0f10000",
+                    "0x62ade08e",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x757364742f757364",
+                    "0xde444324c2a7f80",
+                    "0x62ade091",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x757364632f757364",
+                    "0xde7d1b0f0f10000",
+                    "0x62ade090",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x747573642f757364",
+                    "0xdeb5f2f95b77f80",
+                    "0x62ade0bc",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0x6574682f6d786e",
+                    "0x44f9c0112b17a580000",
+                    "0x62ade0bf",
+                    "0x706f6e7469732d636f696e6765636b6f",
+                    "0xc455"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 247,
+                        "range_check_builtin": 706
+                    },
+                    "n_memory_holes": 2349,
+                    "n_steps": 21104
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0xd",
+                            "0x6274632f757364",
+                            "0x411cbb7c60cb7800000",
+                            "0x62ade0a2",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x6574682f757364",
+                            "0x36431c48afc7000000",
+                            "0x62ade0bf",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x6c756e612f757364",
+                            "0x31feb352c400",
+                            "0x62ade094",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x736f6c2f757364",
+                            "0x1a38688d5a80f0000",
+                            "0x62ade0c0",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x617661782f757364",
+                            "0xd26323adcaec0000",
+                            "0x62ade0c7",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x646f67652f757364",
+                            "0xc0e33222ca5000",
+                            "0x62ade057",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x736869622f757364",
+                            "0x731b0bd7c00",
+                            "0x62ade05b",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x74656d702f757364",
+                            "0x7d78d3108de804",
+                            "0x62ade0cf",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x6461692f757364",
+                            "0xde7d1b0f0f10000",
+                            "0x62ade08e",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x757364742f757364",
+                            "0xde444324c2a7f80",
+                            "0x62ade091",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x757364632f757364",
+                            "0xde7d1b0f0f10000",
+                            "0x62ade090",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x747573642f757364",
+                            "0xdeb5f2f95b77f80",
+                            "0x62ade0bc",
+                            "0x706f6e7469732d636f696e6765636b6f",
+                            "0x6574682f6d786e",
+                            "0x44f9c0112b17a580000",
+                            "0x62ade0bf",
+                            "0x706f6e7469732d636f696e6765636b6f"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x411cbb7c60cb7800000",
+                                    "0x62ade0a2",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x36431c48afc7000000",
+                                    "0x62ade0bf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x6c756e612f757364",
+                                    "0x31feb352c400",
+                                    "0x62ade094",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x736f6c2f757364",
+                                    "0x1a38688d5a80f0000",
+                                    "0x62ade0c0",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            },
+                            {
+                                "data": [
+                                    "0x617661782f757364",
+                                    "0xd26323adcaec0000",
+                                    "0x62ade0c7",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 4
+                            },
+                            {
+                                "data": [
+                                    "0x646f67652f757364",
+                                    "0xc0e33222ca5000",
+                                    "0x62ade057",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 5
+                            },
+                            {
+                                "data": [
+                                    "0x736869622f757364",
+                                    "0x731b0bd7c00",
+                                    "0x62ade05b",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 6
+                            },
+                            {
+                                "data": [
+                                    "0x74656d702f757364",
+                                    "0x7d78d3108de804",
+                                    "0x62ade0cf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 7
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xde7d1b0f0f10000",
+                                    "0x62ade08e",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 8
+                            },
+                            {
+                                "data": [
+                                    "0x757364742f757364",
+                                    "0xde444324c2a7f80",
+                                    "0x62ade091",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 9
+                            },
+                            {
+                                "data": [
+                                    "0x757364632f757364",
+                                    "0xde7d1b0f0f10000",
+                                    "0x62ade090",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 10
+                            },
+                            {
+                                "data": [
+                                    "0x747573642f757364",
+                                    "0xdeb5f2f95b77f80",
+                                    "0x62ade0bc",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 11
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f6d786e",
+                                    "0x44f9c0112b17a580000",
+                                    "0x62ade0bf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 12
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 247,
+                                "range_check_builtin": 703
+                            },
+                            "n_memory_holes": 2293,
+                            "n_steps": 20837
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x411cbb7c60cb7800000",
+                                    "0x62ade0a2",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x36431c48afc7000000",
+                                    "0x62ade0bf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6c756e612f757364",
+                                    "0x31feb352c400",
+                                    "0x62ade094",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736f6c2f757364",
+                                    "0x1a38688d5a80f0000",
+                                    "0x62ade0c0",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x617661782f757364",
+                                    "0xd26323adcaec0000",
+                                    "0x62ade0c7",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x646f67652f757364",
+                                    "0xc0e33222ca5000",
+                                    "0x62ade057",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736869622f757364",
+                                    "0x731b0bd7c00",
+                                    "0x62ade05b",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x74656d702f757364",
+                                    "0x7d78d3108de804",
+                                    "0x62ade0cf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xde7d1b0f0f10000",
+                                    "0x62ade08e",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364742f757364",
+                                    "0xde444324c2a7f80",
+                                    "0x62ade091",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364632f757364",
+                                    "0xde7d1b0f0f10000",
+                                    "0x62ade090",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x747573642f757364",
+                                    "0xdeb5f2f95b77f80",
+                                    "0x62ade0bc",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f6d786e",
+                                    "0x44f9c0112b17a580000",
+                                    "0x62ade0bf",
+                                    "0x706f6e7469732d636f696e6765636b6f"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x485b99c13e713475104278a2dea17daefba9ce951fe5461d3178c2209afe97d",
+                "0x38b85848902a9ba7d6af6681653e5bd6656f3bcc76a7943407f8112e222d4af"
+            ],
+            "transaction_hash": "0x59949c78d504055e1937626115e7e83e25db677b5067129fb032e2eceb45d9"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                    "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                    "0x5af3107a4000",
+                    "0x0",
+                    "0x11"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 2,
+                        "range_check_builtin": 35
+                    },
+                    "n_memory_holes": 42,
+                    "n_steps": 1404
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                            "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                            "0x5af3107a4000",
+                            "0x0",
+                            "0x11"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x1b50749bd19e94c64fb71771c4c92c779fdeac0c281f3305e0b5b5214697b8c",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 1
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 2,
+                                "range_check_builtin": 35
+                            },
+                            "n_memory_holes": 32,
+                            "n_steps": 1344
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                    "0x5af3107a4000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 31
+                                    },
+                                    "n_memory_holes": 26,
+                                    "n_steps": 952
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                            "0x5af3107a4000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                        "class_hash": "0x339e704d3ae446abefd8ed572bc497d403dfc77a891838d5a4c3aa4b3d8dcf2",
+                                        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                                    "0x5af3107a4000",
+                                                    "0x0",
+                                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de"
+                                                ],
+                                                "keys": [
+                                                    "0x194fc63c49b0f07c8e7a78476844837255213824bd6cb81e0ccfb949921aad1"
+                                                ],
+                                                "order": 0
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 31
+                                            },
+                                            "n_memory_holes": 23,
+                                            "n_steps": 892
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                                    "0x5af3107a4000",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 17
+                                                    },
+                                                    "n_memory_holes": 23,
+                                                    "n_steps": 559
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "DELEGATE",
+                                                        "calldata": [
+                                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                                            "0x5af3107a4000",
+                                                            "0x0"
+                                                        ],
+                                                        "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                        "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 2,
+                                                                "range_check_builtin": 17
+                                                            },
+                                                            "n_memory_holes": 20,
+                                                            "n_steps": 499
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [],
+                                                        "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [],
+                                                "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                            }
+                                        ],
+                                        "messages": [
+                                            {
+                                                "order": 0,
+                                                "payload": [
+                                                    "0x0",
+                                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                                    "0x5af3107a4000",
+                                                    "0x0"
+                                                ],
+                                                "to_address": "0xc3511006C04EF1d78af4C8E0e74Ec18A6E64Ff9e"
+                                            }
+                                        ],
+                                        "result": [],
+                                        "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x150faa6a1a1806cf3240c426b58287a21e8434214487b62b42d5f7fd2cdf9bd",
+                "0x4917d302991cbff0025e4c735660052327f9c1ad67cb0f3c8449403cf28ab78"
+            ],
+            "transaction_hash": "0x1b50749bd19e94c64fb71771c4c92c779fdeac0c281f3305e0b5b5214697b8c"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
+                    "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x558f7a100be654beedba7aa633a8ea30c74d31126503e36187d849623e6c07e",
+                    "0x52b7d2dcc80cd2e4000000",
+                    "0x0",
+                    "0xd"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x71c3c99f5cf76fc19945d4b8b7d34c7c5528f22730d56192b50c6bbfd338a64",
+                "contract_address": "0x39455f3490400a006c39b05b60c5e6dc24a8a3f22d4a08843d6d954a7aa18f2",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 4,
+                        "range_check_builtin": 25
+                    },
+                    "n_memory_holes": 58,
+                    "n_steps": 901
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
+                            "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x558f7a100be654beedba7aa633a8ea30c74d31126503e36187d849623e6c07e",
+                            "0x52b7d2dcc80cd2e4000000",
+                            "0x0",
+                            "0xd"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x6a1776964b9f991c710bfe910b8b37578b32b26a7dffd1669a1a59ac94bf82f",
+                        "contract_address": "0x39455f3490400a006c39b05b60c5e6dc24a8a3f22d4a08843d6d954a7aa18f2",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x408daf26b562ab9a890b9e2ca39b645ca5af4809463c9dda2a92934d575a73b",
+                                    "0x1",
+                                    "0x1"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 25
+                            },
+                            "n_memory_holes": 48,
+                            "n_steps": 841
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x558f7a100be654beedba7aa633a8ea30c74d31126503e36187d849623e6c07e",
+                                    "0x52b7d2dcc80cd2e4000000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x39455f3490400a006c39b05b60c5e6dc24a8a3f22d4a08843d6d954a7aa18f2",
+                                "class_hash": "0x71b7f73b5e2b4f81f7cf01d4d1569ccba2921b3fa3170cf11cff3720dfe918e",
+                                "contract_address": "0x7394cbe418daa16e42b87ba67372d4ab4a5df0b05c6e554d158458ce245bc10",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 21
+                                    },
+                                    "n_memory_holes": 42,
+                                    "n_steps": 485
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x3d4ec93714f091a33222a670c383f1ed52b751093774418b6ebedf0d7ef7726",
+                "0x3524fcdea1cb2dacce0b8c46fabfa150cc2440941a1a24c156a9f70a0332b1d"
+            ],
+            "transaction_hash": "0x408daf26b562ab9a890b9e2ca39b645ca5af4809463c9dda2a92934d575a73b"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x2d26be5d70a57b5db072b8b714914e4a2d94f82be260e5b2162d269505f0ed2",
+                    "0x71afd498d0000",
+                    "0x0",
+                    "0xc8d16fcc4a07461563c7eb265503b03ba1661fb2077540ae1c1ce91b0385ca"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x623ce5111775ec86d96652d4c9d83f83e91b76b7bc51d62ea69134b8675e0f1",
+                "contract_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 6,
+                        "range_check_builtin": 29
+                    },
+                    "n_memory_holes": 75,
+                    "n_steps": 849
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x2d26be5d70a57b5db072b8b714914e4a2d94f82be260e5b2162d269505f0ed2",
+                            "0x71afd498d0000",
+                            "0x0"
+                        ],
+                        "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 47,
+                            "n_steps": 540
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "DELEGATE",
+                                "calldata": [
+                                    "0x2d26be5d70a57b5db072b8b714914e4a2d94f82be260e5b2162d269505f0ed2",
+                                    "0x71afd498d0000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                                "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 21
+                                    },
+                                    "n_memory_holes": 44,
+                                    "n_steps": 480
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1"
+                        ],
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x3cf28625429508266f0e9e453c680b711775fcd2b570504c7bd9399e3634c35",
+                "0x2848789a6d921c904bd8db714a5d5389a7a1873f2db0626591ca565e10beae4"
+            ],
+            "transaction_hash": "0x6606fd04124b3264bf6295580bda96455efb7713c2ef9d701f6d5b8c65d409a"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x2",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                    "0x4b74eb5f8cd2e8c8346072d939e3834a720b9e7f5157aaba7a36e47288b831",
+                    "0x3",
+                    "0xa",
+                    "0xd",
+                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                    "0x6c6b935b8bbd400000",
+                    "0x0",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                    "0x6c6b935b8bbd400000",
+                    "0x0",
+                    "0x501b86fe54e53d27c",
+                    "0x0",
+                    "0x2",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                    "0x0",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 70,
+                        "range_check_builtin": 1592
+                    },
+                    "n_memory_holes": 620,
+                    "n_steps": 22503
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x2",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                            "0x4b74eb5f8cd2e8c8346072d939e3834a720b9e7f5157aaba7a36e47288b831",
+                            "0x3",
+                            "0xa",
+                            "0xd",
+                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                            "0x6c6b935b8bbd400000",
+                            "0x0",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                            "0x6c6b935b8bbd400000",
+                            "0x0",
+                            "0x501b86fe54e53d27c",
+                            "0x0",
+                            "0x2",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                            "0x0",
+                            "0x0"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x291ffe912a6d06785b29c28b493b2a5bbf50736f8c2116ed9d083d10bfd61e6",
+                                    "0x3",
+                                    "0x1",
+                                    "0x78294edbfb5e2fc4d",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 5
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 70,
+                                "range_check_builtin": 1592
+                            },
+                            "n_memory_holes": 596,
+                            "n_steps": 22443
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 137
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0",
+                                    "0x501b86fe54e53d27c",
+                                    "0x0",
+                                    "0x2",
+                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                "class_hash": "0x7c4ad808372012f2034b28c2026197663e21cd5a89651bd127800f8aa03f13",
+                                "contract_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 68,
+                                        "range_check_builtin": 1583
+                                    },
+                                    "n_memory_holes": 569,
+                                    "n_steps": 21800
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                            "0x6c6b935b8bbd400000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 62,
+                                            "n_steps": 770
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 0,
+                                                "range_check_builtin": 0
+                                            },
+                                            "n_memory_holes": 0,
+                                            "n_steps": 46
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d"
+                                        ],
+                                        "selector": "0xad5d3ec16e143a33da68c00099116ef328a882b65607bec5b2431267934a20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 0,
+                                                "range_check_builtin": 0
+                                            },
+                                            "n_memory_holes": 0,
+                                            "n_steps": 46
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                        ],
+                                        "selector": "0x3610e8e1835afecdd154863369b91f55612defc17933f83f4425533c435a248"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 94
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 0,
+                                                "range_check_builtin": 0
+                                            },
+                                            "n_memory_holes": 0,
+                                            "n_steps": 133
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1d2f5a02c5ea9c3e75d0c1",
+                                            "0x0",
+                                            "0x5ce72f67bf6f0d40f037262",
+                                            "0x0",
+                                            "0x62ade0f5"
+                                        ],
+                                        "selector": "0x3cb0e1486e633fbe3e2fafe8aedf12b70ca1860e7467ddb75a17858cde39312"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                            "0x3635c9adc5dea00000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 5
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 139
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x3635c9adc5dea00000",
+                                            "0x0",
+                                            "0x0",
+                                            "0x0",
+                                            "0x2",
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                            "0xd3c21bcecceda0ffffff"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                        "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 20,
+                                                "range_check_builtin": 727
+                                            },
+                                            "n_memory_holes": 180,
+                                            "n_steps": 9201
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                                "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 0
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 133
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1d2f5a02c5ea9c3e75d0c1",
+                                                    "0x0",
+                                                    "0x5ce72f67bf6f0d40f037262",
+                                                    "0x0",
+                                                    "0x62ade0f5"
+                                                ],
+                                                "selector": "0x3cb0e1486e633fbe3e2fafe8aedf12b70ca1860e7467ddb75a17858cde39312"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                    "0x3635c9adc5dea00000",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 8,
+                                                        "range_check_builtin": 32
+                                                    },
+                                                    "n_memory_holes": 62,
+                                                    "n_steps": 770
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x10fa8bdf599ba26c7",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                                "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [
+                                                    {
+                                                        "data": [
+                                                            "0x1d2f58f31d2ca6a4bba9fa",
+                                                            "0x0",
+                                                            "0x5ce732cb1c09e99eda37262",
+                                                            "0x0"
+                                                        ],
+                                                        "keys": [
+                                                            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                        ],
+                                                        "order": 0
+                                                    },
+                                                    {
+                                                        "data": [
+                                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                            "0x0",
+                                                            "0x0",
+                                                            "0x3635c9adc5dea00000",
+                                                            "0x0",
+                                                            "0x10fa8bdf599ba26c7",
+                                                            "0x0",
+                                                            "0x0",
+                                                            "0x0",
+                                                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124"
+                                                        ],
+                                                        "keys": [
+                                                            "0xe316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab"
+                                                        ],
+                                                        "order": 1
+                                                    }
+                                                ],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 6,
+                                                        "range_check_builtin": 493
+                                                    },
+                                                    "n_memory_holes": 65,
+                                                    "n_steps": 5614
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [
+                                                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                                            "0x10fa8bdf599ba26c7",
+                                                            "0x0"
+                                                        ],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                        "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 4,
+                                                                "range_check_builtin": 21
+                                                            },
+                                                            "n_memory_holes": 42,
+                                                            "n_steps": 485
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x1"
+                                                        ],
+                                                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                                    },
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [
+                                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                        ],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                        "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 1,
+                                                                "range_check_builtin": 3
+                                                            },
+                                                            "n_memory_holes": 11,
+                                                            "n_steps": 94
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x1d2f58f31d2ca6a4bba9fa",
+                                                            "0x0"
+                                                        ],
+                                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                                    },
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [
+                                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                        ],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 1,
+                                                                "range_check_builtin": 3
+                                                            },
+                                                            "n_memory_holes": 11,
+                                                            "n_steps": 94
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x5ce732cb1c09e99eda37262",
+                                                            "0x0"
+                                                        ],
+                                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [],
+                                                "selector": "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x2",
+                                            "0x3635c9adc5dea00000",
+                                            "0x0",
+                                            "0x10fa8bdf599ba26c7",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x3276861cf5e05d6daf8f352cabb47df623eb10c383ab742fcc7abea94d5c5cc"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                            "0x10fa8bdf599ba26c7",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 5
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 139
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                            "0x3635c9adc5dea00000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 5
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 139
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x10fa8bdf599ba26c7",
+                                            "0x0",
+                                            "0x3635c9adc5dea00000",
+                                            "0x0",
+                                            "0x1",
+                                            "0x0",
+                                            "0x1",
+                                            "0x0",
+                                            "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                            "0xd3c21bcecceda0ffffff"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                        "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 26,
+                                                "range_check_builtin": 403
+                                            },
+                                            "n_memory_holes": 228,
+                                            "n_steps": 6543
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                                "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 0
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 133
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1d2f58f31d2ca6a4bba9fa",
+                                                    "0x0",
+                                                    "0x5ce732cb1c09e99eda37262",
+                                                    "0x0",
+                                                    "0x62ade12a"
+                                                ],
+                                                "selector": "0x3cb0e1486e633fbe3e2fafe8aedf12b70ca1860e7467ddb75a17858cde39312"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                    "0x10fa8bdf599ba26c7",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 8,
+                                                        "range_check_builtin": 32
+                                                    },
+                                                    "n_memory_holes": 62,
+                                                    "n_steps": 770
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                    "0x360c298244080d8035",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 8,
+                                                        "range_check_builtin": 32
+                                                    },
+                                                    "n_memory_holes": 62,
+                                                    "n_steps": 770
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124"
+                                                ],
+                                                "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                                "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [
+                                                    {
+                                                        "data": [
+                                                            "0x1d2f5a02c5ea9c3e75d0c1",
+                                                            "0x0",
+                                                            "0x5ce7362bdea20ddf5b0f297",
+                                                            "0x0"
+                                                        ],
+                                                        "keys": [
+                                                            "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                        ],
+                                                        "order": 2
+                                                    },
+                                                    {
+                                                        "data": [
+                                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                            "0x10fa8bdf599ba26c7",
+                                                            "0x0",
+                                                            "0x360c298244080d8035",
+                                                            "0x0"
+                                                        ],
+                                                        "keys": [
+                                                            "0x34e55c1cd55f1338241b50d352f0e91c7e4ffad0e4271d64eb347589ebdfd16"
+                                                        ],
+                                                        "order": 3
+                                                    }
+                                                ],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 193
+                                                    },
+                                                    "n_memory_holes": 70,
+                                                    "n_steps": 2815
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [
+                                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                        ],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                        "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 1,
+                                                                "range_check_builtin": 3
+                                                            },
+                                                            "n_memory_holes": 11,
+                                                            "n_steps": 94
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x1d2f5a02c5ea9c3e75d0c1",
+                                                            "0x0"
+                                                        ],
+                                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                                    },
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [
+                                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                        ],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 1,
+                                                                "range_check_builtin": 3
+                                                            },
+                                                            "n_memory_holes": 11,
+                                                            "n_steps": 94
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x5ce7362bdea20ddf5b0f297",
+                                                            "0x0"
+                                                        ],
+                                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                                    },
+                                                    {
+                                                        "call_type": "CALL",
+                                                        "calldata": [],
+                                                        "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 0,
+                                                                "range_check_builtin": 0
+                                                            },
+                                                            "n_memory_holes": 0,
+                                                            "n_steps": 46
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x0"
+                                                        ],
+                                                        "selector": "0x845a08a51fd77880cb14b0e33c63bb1b6d98e77c57673f0aa3e31a9fd2ca64"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x78294edbfb5e2fc4d",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x10fa8bdf599ba26c7",
+                                            "0x0",
+                                            "0x360c298244080d8035",
+                                            "0x0",
+                                            "0x78294edbfb5e2fc4d",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                            "0x78294edbfb5e2fc4d",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x263acca23357479031157e30053fe10598077f24f427ac1b1de85487f5cd124",
+                                                    "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                                    "0x78294edbfb5e2fc4d",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                ],
+                                                "order": 4
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 4,
+                                                "range_check_builtin": 30
+                                            },
+                                            "n_memory_holes": 40,
+                                            "n_steps": 624
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x78294edbfb5e2fc4d",
+                                    "0x0"
+                                ],
+                                "selector": "0x4b74eb5f8cd2e8c8346072d939e3834a720b9e7f5157aaba7a36e47288b831"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x78294edbfb5e2fc4d",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x78294edbfb5e2fc4d",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x31e430ec9d86da5b88db27f604b260ed23d42b2202d3f4992bfca01ee7ba260",
+                "0x610baa6a1bc48479e857d6193163e2d9b24c5504c70bd8ac2d2f632dcc4b42e"
+            ],
+            "transaction_hash": "0x291ffe912a6d06785b29c28b493b2a5bbf50736f8c2116ed9d083d10bfd61e6"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x3",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x3",
+                    "0x3",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70",
+                    "0x6",
+                    "0xc",
+                    "0x12",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0xad78ebc5ac6200000",
+                    "0x0",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0xc705a3",
+                    "0x0",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                    "0xad78ebc5ac6200000",
+                    "0x0",
+                    "0xc705a3",
+                    "0x0",
+                    "0xac9ae05a71ebc0000",
+                    "0x0",
+                    "0xc606e3",
+                    "0x0",
+                    "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                    "0x62adee95",
+                    "0x29"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 30,
+                        "range_check_builtin": 648
+                    },
+                    "n_memory_holes": 287,
+                    "n_steps": 9518
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x3",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x3",
+                            "0x3",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70",
+                            "0x6",
+                            "0xc",
+                            "0x12",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0xad78ebc5ac6200000",
+                            "0x0",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0xc705a3",
+                            "0x0",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                            "0xad78ebc5ac6200000",
+                            "0x0",
+                            "0xc705a3",
+                            "0x0",
+                            "0xac9ae05a71ebc0000",
+                            "0x0",
+                            "0xc606e3",
+                            "0x0",
+                            "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                            "0x62adee95",
+                            "0x29"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x4a94a65efa1af680e65b7b4d46850deecc493e5c4c3a7de17b25d1bec6ea7c",
+                                    "0x8",
+                                    "0x1",
+                                    "0x1",
+                                    "0xad781b168878b922d",
+                                    "0x0",
+                                    "0xc705a3",
+                                    "0x0",
+                                    "0x2e0bb9e8e52c",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 2
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 30,
+                                "range_check_builtin": 648
+                            },
+                            "n_memory_holes": 254,
+                            "n_steps": 9458
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                    "0xad78ebc5ac6200000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 139
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                    "0xc705a3",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 139
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                    "0xad78ebc5ac6200000",
+                                    "0x0",
+                                    "0xc705a3",
+                                    "0x0",
+                                    "0xac9ae05a71ebc0000",
+                                    "0x0",
+                                    "0xc606e3",
+                                    "0x0",
+                                    "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                    "0x62adee95"
+                                ],
+                                "caller_address": "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 26,
+                                        "range_check_builtin": 634
+                                    },
+                                    "n_memory_holes": 213,
+                                    "n_steps": 8558
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 0,
+                                                "range_check_builtin": 0
+                                            },
+                                            "n_memory_holes": 0,
+                                            "n_steps": 133
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x48fa65f22a978efbf4bdd50",
+                                            "0x0",
+                                            "0x53ba68204e62",
+                                            "0x0",
+                                            "0x62ade0f5"
+                                        ],
+                                        "selector": "0x3cb0e1486e633fbe3e2fafe8aedf12b70ca1860e7467ddb75a17858cde39312"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                            "0xad781b168878b922d",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 774
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb",
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                            "0xc705a3",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 774
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4b5bea075717d1617c650e937d739a83fb78712c3613233f4f021de8b201ceb"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x48fa669fa2b2a5846d76f7d",
+                                                    "0x0",
+                                                    "0x53ba68e75405",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                ],
+                                                "order": 0
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0xad781b168878b922d",
+                                                    "0x0",
+                                                    "0xc705a3",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x34e55c1cd55f1338241b50d352f0e91c7e4ffad0e4271d64eb347589ebdfd16"
+                                                ],
+                                                "order": 1
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 4,
+                                                "range_check_builtin": 347
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 4167
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                                ],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 96
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x48fa669fa2b2a5846d76f7d",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                                ],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 96
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x53ba68e75405",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 0
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 46
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x845a08a51fd77880cb14b0e33c63bb1b6d98e77c57673f0aa3e31a9fd2ca64"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x2e0bb9e8e52c",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0xad781b168878b922d",
+                                    "0x0",
+                                    "0xc705a3",
+                                    "0x0",
+                                    "0x2e0bb9e8e52c",
+                                    "0x0"
+                                ],
+                                "selector": "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x1",
+                            "0xad781b168878b922d",
+                            "0x0",
+                            "0xc705a3",
+                            "0x0",
+                            "0x2e0bb9e8e52c",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0xad781b168878b922d",
+                    "0x0",
+                    "0xc705a3",
+                    "0x0",
+                    "0x2e0bb9e8e52c",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x42b650679ce36ea25fa0d2d7d096e15565cdc6173e6a1be78f0c01a6e838ff4",
+                "0x4981840c68ac12dc170bf3228c47c5952df3ec373a6643999facc766ecbd81b"
+            ],
+            "transaction_hash": "0x4a94a65efa1af680e65b7b4d46850deecc493e5c4c3a7de17b25d1bec6ea7c"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                    "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+                    "0x2",
+                    "0x2db759699a6090e24e949cf8e7583c4dfbc59f63b7b43e606b7937861384b22",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x5c572a8a149ca65da12d4c4955ff290a78200e01a511f80d6869bf2776e594c",
+                "entry_point_type": "CONSTRUCTOR",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 0,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 1
+                    },
+                    "n_memory_holes": 2,
+                    "n_steps": 219
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x2db759699a6090e24e949cf8e7583c4dfbc59f63b7b43e606b7937861384b22",
+                            "0x0"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x5c572a8a149ca65da12d4c4955ff290a78200e01a511f80d6869bf2776e594c",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x5c572a8a149ca65da12d4c4955ff290a78200e01a511f80d6869bf2776e594c",
+                                    "0x2db759699a6090e24e949cf8e7583c4dfbc59f63b7b43e606b7937861384b22",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x10c19bef19acd19b2c9f4caa40fd47c9fbe1d9f91324d44dcd36be2dae96784"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 0,
+                                "range_check_builtin": 0
+                            },
+                            "n_memory_holes": 0,
+                            "n_steps": 141
+                        },
+                        "internal_calls": [],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+            },
+            "signature": [],
+            "transaction_hash": "0x357787f7ff27bb9cff4bcf1953826f99ac00e5ab1da5b595854c39e35a664d4"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0xd",
+                    "0xd",
+                    "0x3",
+                    "0x6274632f757364",
+                    "0x40ede74c319d8000000",
+                    "0x62ade078",
+                    "0x706f6e7469732d636f696e62617365",
+                    "0x6574682f757364",
+                    "0x362c12c77b4fda0000",
+                    "0x62ade078",
+                    "0x706f6e7469732d636f696e62617365",
+                    "0x6461692f757364",
+                    "0xde05bc096e9c000",
+                    "0x62ade078",
+                    "0x706f6e7469732d636f696e62617365",
+                    "0xc456"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 57,
+                        "range_check_builtin": 166
+                    },
+                    "n_memory_holes": 545,
+                    "n_steps": 5102
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x3",
+                            "0x6274632f757364",
+                            "0x40ede74c319d8000000",
+                            "0x62ade078",
+                            "0x706f6e7469732d636f696e62617365",
+                            "0x6574682f757364",
+                            "0x362c12c77b4fda0000",
+                            "0x62ade078",
+                            "0x706f6e7469732d636f696e62617365",
+                            "0x6461692f757364",
+                            "0xde05bc096e9c000",
+                            "0x62ade078",
+                            "0x706f6e7469732d636f696e62617365"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x40ede74c319d8000000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x362c12c77b4fda0000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xde05bc096e9c000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 57,
+                                "range_check_builtin": 163
+                            },
+                            "n_memory_holes": 529,
+                            "n_steps": 4835
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x40ede74c319d8000000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x362c12c77b4fda0000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xde05bc096e9c000",
+                                    "0x62ade078",
+                                    "0x706f6e7469732d636f696e62617365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x11d4bb332230dd1545f5701996ea99472d37aa9673ffddb99ee5c8293e45102",
+                "0x4a74caeccbb6c94b43394cb01867d8b1698eab616f7257d276cc1ee4e7cea9b"
+            ],
+            "transaction_hash": "0x75a828662d76bacaba069a75ccc892c65bcabb15a4214a22f156ec1b46887a8"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                    "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                    "0x5af3107a4000",
+                    "0x0",
+                    "0x12"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 2,
+                        "range_check_builtin": 35
+                    },
+                    "n_memory_holes": 42,
+                    "n_steps": 1404
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                            "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                            "0x5af3107a4000",
+                            "0x0",
+                            "0x12"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x3f9404e5fef5ddf80c5c012b3bd1b9afef61b57e08c40912cef861ff8e2676",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 1
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 2,
+                                "range_check_builtin": 35
+                            },
+                            "n_memory_holes": 32,
+                            "n_steps": 1344
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                    "0x5af3107a4000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 31
+                                    },
+                                    "n_memory_holes": 26,
+                                    "n_steps": 952
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                            "0x5af3107a4000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                        "class_hash": "0x339e704d3ae446abefd8ed572bc497d403dfc77a891838d5a4c3aa4b3d8dcf2",
+                                        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                                    "0x5af3107a4000",
+                                                    "0x0",
+                                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de"
+                                                ],
+                                                "keys": [
+                                                    "0x194fc63c49b0f07c8e7a78476844837255213824bd6cb81e0ccfb949921aad1"
+                                                ],
+                                                "order": 0
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 31
+                                            },
+                                            "n_memory_holes": 23,
+                                            "n_steps": 892
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                                    "0x5af3107a4000",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 17
+                                                    },
+                                                    "n_memory_holes": 23,
+                                                    "n_steps": 559
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "DELEGATE",
+                                                        "calldata": [
+                                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                                            "0x5af3107a4000",
+                                                            "0x0"
+                                                        ],
+                                                        "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                        "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 2,
+                                                                "range_check_builtin": 17
+                                                            },
+                                                            "n_memory_holes": 20,
+                                                            "n_steps": 499
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [],
+                                                        "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [],
+                                                "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                            }
+                                        ],
+                                        "messages": [
+                                            {
+                                                "order": 0,
+                                                "payload": [
+                                                    "0x0",
+                                                    "0x9483a265580ebddf424be90ac98bdd5c5cf7a9e0",
+                                                    "0x5af3107a4000",
+                                                    "0x0"
+                                                ],
+                                                "to_address": "0xc3511006C04EF1d78af4C8E0e74Ec18A6E64Ff9e"
+                                            }
+                                        ],
+                                        "result": [],
+                                        "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x2efe00ed6811b916252c0bb6c14bce9b355cffa8b6ccd19efff56520735bd4a",
+                "0x31f7357b68564ee9282020b6ca8c4836a51efdc29f3e264dc161cd55cd4b70"
+            ],
+            "transaction_hash": "0x3f9404e5fef5ddf80c5c012b3bd1b9afef61b57e08c40912cef861ff8e2676"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x21",
+                    "0x21",
+                    "0x8",
+                    "0x6274632f757364",
+                    "0x40e711960d9da000000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x6574682f757364",
+                    "0x36275adb4878380000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x6c756e612f757364",
+                    "0x3221a0052000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x736f6c2f757364",
+                    "0x1a2e6a992b12a8000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x646f67652f757364",
+                    "0xbf3e198c426000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x736869622f757364",
+                    "0x72b676a2e00",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x6461692f757364",
+                    "0xddfa5da75f54000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0x757364632f757364",
+                    "0xddfdc6c4ca50000",
+                    "0x62ade0fe",
+                    "0x706f6e7469732d67656d696e69",
+                    "0xc457"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 152,
+                        "range_check_builtin": 436
+                    },
+                    "n_memory_holes": 1438,
+                    "n_steps": 13121
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x8",
+                            "0x6274632f757364",
+                            "0x40e711960d9da000000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x6574682f757364",
+                            "0x36275adb4878380000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x6c756e612f757364",
+                            "0x3221a0052000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x736f6c2f757364",
+                            "0x1a2e6a992b12a8000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x646f67652f757364",
+                            "0xbf3e198c426000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x736869622f757364",
+                            "0x72b676a2e00",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x6461692f757364",
+                            "0xddfa5da75f54000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69",
+                            "0x757364632f757364",
+                            "0xddfdc6c4ca50000",
+                            "0x62ade0fe",
+                            "0x706f6e7469732d67656d696e69"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x40e711960d9da000000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x36275adb4878380000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x6c756e612f757364",
+                                    "0x3221a0052000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x736f6c2f757364",
+                                    "0x1a2e6a992b12a8000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            },
+                            {
+                                "data": [
+                                    "0x646f67652f757364",
+                                    "0xbf3e198c426000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 4
+                            },
+                            {
+                                "data": [
+                                    "0x736869622f757364",
+                                    "0x72b676a2e00",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 5
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xddfa5da75f54000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 6
+                            },
+                            {
+                                "data": [
+                                    "0x757364632f757364",
+                                    "0xddfdc6c4ca50000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 7
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 152,
+                                "range_check_builtin": 433
+                            },
+                            "n_memory_holes": 1402,
+                            "n_steps": 12854
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x40e711960d9da000000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x36275adb4878380000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6c756e612f757364",
+                                    "0x3221a0052000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736f6c2f757364",
+                                    "0x1a2e6a992b12a8000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x646f67652f757364",
+                                    "0xbf3e198c426000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736869622f757364",
+                                    "0x72b676a2e00",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xddfa5da75f54000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 90
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364632f757364",
+                                    "0xddfdc6c4ca50000",
+                                    "0x62ade0fe",
+                                    "0x706f6e7469732d67656d696e69"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x6aa48576a055053d9fb0e0338eae9d05eb40d9c326cc15e6626f9df29080694",
+                "0x2c8c39047d78b73ea7c8b2274f045676a13f29752f6c6f59e162574c11e78c1"
+            ],
+            "transaction_hash": "0x763b470debd148744fa6aa3eadd385870bfc6f645374c4f55c8d26ef242d0e"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x28af510e1032f6d933ae6eb287791aa458a6c71119d5a4421c0782285cb2d81",
+                    "0x2913ee03e5e3308c41e308bd391ea4faac9b9cb5062c76a6b3ab4f65397e106",
+                    "0x0",
+                    "0xc",
+                    "0xc",
+                    "0x4",
+                    "0x79aec12a5994d2a7caa40af956225c13f9ceafcdccaead0b6dd3a6f7cc9180e",
+                    "0x265ed0d3271b1806afe0522f7b9a29c7510b585fb0b0aabb7e113518b36c999",
+                    "0x33de17357a278cbe80a82dc387c77d69400568410230611fceee5ad08c14f97",
+                    "0x1338cce88e58ec32865546b23743b83d26594d500a9f201b685c7578459569",
+                    "0x6",
+                    "0x21a3f11c9ee7096f4a64c415b3c44a354f9db439729f43a5482d03447f8bc24",
+                    "0x2bedc7f7a58166ebf60e3437d4c918caa3d9f1b593b0f848ef21da42e3991fc",
+                    "0x1860f26680aaa18ec036afeec1dae56699b9db891e5b7518945538531609da4",
+                    "0x7e654490df9cbe61153116e06c52e885fa9000161d70442d38940bdaf74e7fc",
+                    "0x7876d4a68f22be485dac282e525540b825c121d1457819451d4084c804cd792",
+                    "0x2077d983e62aacfd4e8ed4401cb5aefcd746486eceb4489f639dfebf1e8f54a",
+                    "0x151d"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x7319e2f01b0947afd86c0bb0e95029551b32f6dc192c47b2e8b08415eebbc25",
+                "contract_address": "0x67c4bb900d45780545e1d8c258fa754b279246fd8b43cd35ac9fda2d0367b85",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 4
+                    },
+                    "n_memory_holes": 25,
+                    "n_steps": 276
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x4",
+                            "0x79aec12a5994d2a7caa40af956225c13f9ceafcdccaead0b6dd3a6f7cc9180e",
+                            "0x265ed0d3271b1806afe0522f7b9a29c7510b585fb0b0aabb7e113518b36c999",
+                            "0x33de17357a278cbe80a82dc387c77d69400568410230611fceee5ad08c14f97",
+                            "0x1338cce88e58ec32865546b23743b83d26594d500a9f201b685c7578459569",
+                            "0x6",
+                            "0x21a3f11c9ee7096f4a64c415b3c44a354f9db439729f43a5482d03447f8bc24",
+                            "0x2bedc7f7a58166ebf60e3437d4c918caa3d9f1b593b0f848ef21da42e3991fc",
+                            "0x1860f26680aaa18ec036afeec1dae56699b9db891e5b7518945538531609da4",
+                            "0x7e654490df9cbe61153116e06c52e885fa9000161d70442d38940bdaf74e7fc",
+                            "0x7876d4a68f22be485dac282e525540b825c121d1457819451d4084c804cd792",
+                            "0x2077d983e62aacfd4e8ed4401cb5aefcd746486eceb4489f639dfebf1e8f54a"
+                        ],
+                        "caller_address": "0x67c4bb900d45780545e1d8c258fa754b279246fd8b43cd35ac9fda2d0367b85",
+                        "class_hash": "0x590267e2a8bdb5a5c5c6b8f51751fc661866d96e6dec956f8562f54ecdffabc",
+                        "contract_address": "0x28af510e1032f6d933ae6eb287791aa458a6c71119d5a4421c0782285cb2d81",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x21a3f11c9ee7096f4a64c415b3c44a354f9db439729f43a5482d03447f8bc24",
+                                    "0x2bedc7f7a58166ebf60e3437d4c918caa3d9f1b593b0f848ef21da42e3991fc",
+                                    "0x1860f26680aaa18ec036afeec1dae56699b9db891e5b7518945538531609da4",
+                                    "0x7e654490df9cbe61153116e06c52e885fa9000161d70442d38940bdaf74e7fc",
+                                    "0x7876d4a68f22be485dac282e525540b825c121d1457819451d4084c804cd792",
+                                    "0x2077d983e62aacfd4e8ed4401cb5aefcd746486eceb4489f639dfebf1e8f54a"
+                                ],
+                                "keys": [
+                                    "0x79aec12a5994d2a7caa40af956225c13f9ceafcdccaead0b6dd3a6f7cc9180e",
+                                    "0x265ed0d3271b1806afe0522f7b9a29c7510b585fb0b0aabb7e113518b36c999",
+                                    "0x33de17357a278cbe80a82dc387c77d69400568410230611fceee5ad08c14f97",
+                                    "0x1338cce88e58ec32865546b23743b83d26594d500a9f201b685c7578459569"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 0,
+                                "range_check_builtin": 2
+                            },
+                            "n_memory_holes": 10,
+                            "n_steps": 43
+                        },
+                        "internal_calls": [],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x2913ee03e5e3308c41e308bd391ea4faac9b9cb5062c76a6b3ab4f65397e106"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x41a07f3bc32b8b9334d6b191a0885ed36b85780be49affd5575940a61cb451e",
+                "0x708acf44d8dc2001f427d7ebb642a0ed8bac873e7b6f04a55708d4e3c73dcbe"
+            ],
+            "transaction_hash": "0x1b62451ef233a58120dfc6757f90ec86221379ec9b7e57260c55432ba7e30a4"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x11",
+                    "0x11",
+                    "0x4",
+                    "0x6274632f7573642d3230323230363234",
+                    "0x40d2b32f34809c00000",
+                    "0x62ade102",
+                    "0x706f6e7469732d62696e616e6365",
+                    "0x6274632f7573642d3230323230393330",
+                    "0x414d32ee4be5f800000",
+                    "0x62ade102",
+                    "0x706f6e7469732d62696e616e6365",
+                    "0x6574682f7573642d3230323230363234",
+                    "0x361c4fe50f34240000",
+                    "0x62ade102",
+                    "0x706f6e7469732d62696e616e6365",
+                    "0x6574682f7573642d3230323230393330",
+                    "0x365727983c314e0000",
+                    "0x62ade102",
+                    "0x706f6e7469732d62696e616e6365",
+                    "0xc458"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 76,
+                        "range_check_builtin": 220
+                    },
+                    "n_memory_holes": 726,
+                    "n_steps": 6701
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x4",
+                            "0x6274632f7573642d3230323230363234",
+                            "0x40d2b32f34809c00000",
+                            "0x62ade102",
+                            "0x706f6e7469732d62696e616e6365",
+                            "0x6274632f7573642d3230323230393330",
+                            "0x414d32ee4be5f800000",
+                            "0x62ade102",
+                            "0x706f6e7469732d62696e616e6365",
+                            "0x6574682f7573642d3230323230363234",
+                            "0x361c4fe50f34240000",
+                            "0x62ade102",
+                            "0x706f6e7469732d62696e616e6365",
+                            "0x6574682f7573642d3230323230393330",
+                            "0x365727983c314e0000",
+                            "0x62ade102",
+                            "0x706f6e7469732d62696e616e6365"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f7573642d3230323230363234",
+                                    "0x40d2b32f34809c00000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6274632f7573642d3230323230393330",
+                                    "0x414d32ee4be5f800000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f7573642d3230323230363234",
+                                    "0x361c4fe50f34240000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f7573642d3230323230393330",
+                                    "0x365727983c314e0000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 76,
+                                "range_check_builtin": 217
+                            },
+                            "n_memory_holes": 706,
+                            "n_steps": 6434
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f7573642d3230323230363234",
+                                    "0x40d2b32f34809c00000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f7573642d3230323230393330",
+                                    "0x414d32ee4be5f800000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f7573642d3230323230363234",
+                                    "0x361c4fe50f34240000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f7573642d3230323230393330",
+                                    "0x365727983c314e0000",
+                                    "0x62ade102",
+                                    "0x706f6e7469732d62696e616e6365"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x1cfb64db8a46b9c7c56ac7fa8d4abddc2cca06a44d0f1b966195594a32bbdf0",
+                "0x71c86c0bcff7ea4f3751fd1911a950a0fd4da0da4a8b7ede99ff27a6031257a"
+            ],
+            "transaction_hash": "0xe28d927a92a11eaa0d68062cc63a35c7cf75b730e9d52a27822e08ced4798c"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x2",
+                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada",
+                    "0x3",
+                    "0xa",
+                    "0xd",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x7895ee9c8d2d9338f",
+                    "0x0",
+                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x7895ee9c8d2d9338f",
+                    "0x0",
+                    "0x10f41c8da5fc24112",
+                    "0x0",
+                    "0x35f782fc9b9dccdade",
+                    "0x0",
+                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                    "0x62adee62",
+                    "0x12"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 29,
+                        "range_check_builtin": 348
+                    },
+                    "n_memory_holes": 329,
+                    "n_steps": 6866
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x2",
+                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada",
+                            "0x3",
+                            "0xa",
+                            "0xd",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x7895ee9c8d2d9338f",
+                            "0x0",
+                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x7895ee9c8d2d9338f",
+                            "0x0",
+                            "0x10f41c8da5fc24112",
+                            "0x0",
+                            "0x35f782fc9b9dccdade",
+                            "0x0",
+                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                            "0x62adee62",
+                            "0x12"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6ea17c1188070efe7504c288969424e5c750fd667e5074819daef14f2f98051",
+                                    "0x5",
+                                    "0x1",
+                                    "0x1109e5157d1a9f8d0",
+                                    "0x0",
+                                    "0x363d05301b3fadc74b",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 5
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 29,
+                                "range_check_builtin": 348
+                            },
+                            "n_memory_holes": 305,
+                            "n_steps": 6806
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                    "0x7895ee9c8d2d9338f",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [
+                                    {
+                                        "data": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                            "0x7895ee9c8d2d9338f",
+                                            "0x0"
+                                        ],
+                                        "keys": [
+                                            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+                                        ],
+                                        "order": 0
+                                    }
+                                ],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 45
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 530
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                    "0x7895ee9c8d2d9338f",
+                                    "0x0",
+                                    "0x10f41c8da5fc24112",
+                                    "0x0",
+                                    "0x35f782fc9b9dccdade",
+                                    "0x0",
+                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                    "0x62adee62"
+                                ],
+                                "caller_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 25,
+                                        "range_check_builtin": 299
+                                    },
+                                    "n_memory_holes": 267,
+                                    "n_steps": 5750
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 94
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                            "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                            "0x7895ee9c8d2d9338f",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                    "0x7895ee9c8d2d9338f",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                ],
+                                                "order": 1
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0x0",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+                                                ],
+                                                "order": 2
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 46
+                                            },
+                                            "n_memory_holes": 66,
+                                            "n_steps": 1004
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x1d2f58f22799446ccbd7f1",
+                                                    "0x0",
+                                                    "0x5ce732c80e4f0c2b6032b4c",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                ],
+                                                "order": 3
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0x1109e5157d1a9f8d0",
+                                                    "0x0",
+                                                    "0x363d05301b3fadc74b",
+                                                    "0x0",
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4"
+                                                ],
+                                                "keys": [
+                                                    "0x243e1de00e8a6bc1dfa3e950e6ade24c52e4a25de4dee7fb5affe918ad1e744"
+                                                ],
+                                                "order": 4
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 15,
+                                                "range_check_builtin": 233
+                                            },
+                                            "n_memory_holes": 191,
+                                            "n_steps": 4124
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1d2f5a02c5ea9c3e75d0c1",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x5ce7362bdea20ddf5b0f297",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 0
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 46
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x845a08a51fd77880cb14b0e33c63bb1b6d98e77c57673f0aa3e31a9fd2ca64"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x1109e5157d1a9f8d0",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 21
+                                                    },
+                                                    "n_memory_holes": 44,
+                                                    "n_steps": 481
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x363d05301b3fadc74b",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 21
+                                                    },
+                                                    "n_memory_holes": 44,
+                                                    "n_steps": 481
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1d2f58f22799446ccbd7f1",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17"
+                                                ],
+                                                "caller_address": "0x682bde101e0fa17bb61d867a14db62ddd192d35cc4ad2109e91429e2e4fca17",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x5ce732c80e4f0c2b6032b4c",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1109e5157d1a9f8d0",
+                                            "0x0",
+                                            "0x363d05301b3fadc74b",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x3e8cfd4725c1e28fa4a6e3e468b4fcf75367166b850ac5f04e33ec843e82c1"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x1109e5157d1a9f8d0",
+                                    "0x0",
+                                    "0x363d05301b3fadc74b",
+                                    "0x0"
+                                ],
+                                "selector": "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x1109e5157d1a9f8d0",
+                            "0x0",
+                            "0x363d05301b3fadc74b",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1109e5157d1a9f8d0",
+                    "0x0",
+                    "0x363d05301b3fadc74b",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x529c890c42d6bf33c5a7c51ba06a038fb3d80878179cb60b99cbda3e5f03837",
+                "0x6ebaaac2dbd81e6b9f2d275f29e679a3d86c3349f99703791aa1f4f04edd477"
+            ],
+            "transaction_hash": "0x6ea17c1188070efe7504c288969424e5c750fd667e5074819daef14f2f98051"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x37921808d53dfbcafd48bf706ef482201ae20e2e6a7929d8e885a5307007c60",
+                    "0x306e6b6954a02cb8cec57b60a954e51a8f3be967365666019d5bc8ba7c7eeb1",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x1"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x7583599f20b8c0e94831494659f1ffc0858f4d41c2813aef0bc542f2487c2df",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 5
+                    },
+                    "n_memory_holes": 10,
+                    "n_steps": 610
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x37921808d53dfbcafd48bf706ef482201ae20e2e6a7929d8e885a5307007c60",
+                            "0x306e6b6954a02cb8cec57b60a954e51a8f3be967365666019d5bc8ba7c7eeb1",
+                            "0x0",
+                            "0x0",
+                            "0x0",
+                            "0x1"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x7583599f20b8c0e94831494659f1ffc0858f4d41c2813aef0bc542f2487c2df",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x552334e3dfb31d87d62eb9c1483551c30f03c91e5aa7af376df030646c21123",
+                                    "0x4",
+                                    "0x3",
+                                    "0x1",
+                                    "0x2",
+                                    "0x3"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 0,
+                                "range_check_builtin": 5
+                            },
+                            "n_memory_holes": 3,
+                            "n_steps": 550
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [],
+                                "caller_address": "0x7583599f20b8c0e94831494659f1ffc0858f4d41c2813aef0bc542f2487c2df",
+                                "class_hash": "0x7574dc7dbddd75e6dc9c12c7259b26045c3d2a5af70b35692a60cb05be0817f",
+                                "contract_address": "0x37921808d53dfbcafd48bf706ef482201ae20e2e6a7929d8e885a5307007c60",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 0,
+                                        "range_check_builtin": 1
+                                    },
+                                    "n_memory_holes": 0,
+                                    "n_steps": 112
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3",
+                                    "0x1",
+                                    "0x2",
+                                    "0x3"
+                                ],
+                                "selector": "0x306e6b6954a02cb8cec57b60a954e51a8f3be967365666019d5bc8ba7c7eeb1"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x3",
+                            "0x1",
+                            "0x2",
+                            "0x3"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x3",
+                    "0x1",
+                    "0x2",
+                    "0x3"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x83341057135b9c5071a577d863ed682517d1692e599731bafb0aaefd14cdc5",
+                "0x5c98f7bb9b8b0df75659b85f7cb25527a7906874d9956204929668cb86348c4"
+            ],
+            "transaction_hash": "0x552334e3dfb31d87d62eb9c1483551c30f03c91e5aa7af376df030646c21123"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x3be62320d24b19731ae1f639bdaa1ce6cde23a71bca9029da979bbf1274f553",
+                    "0x71afd498d0000",
+                    "0x0",
+                    "0xce10622c09e46211ba58240bee6d1d4ca2d0e7e00ec34184899e1247e6cfbe"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x623ce5111775ec86d96652d4c9d83f83e91b76b7bc51d62ea69134b8675e0f1",
+                "contract_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 6,
+                        "range_check_builtin": 29
+                    },
+                    "n_memory_holes": 73,
+                    "n_steps": 853
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x3be62320d24b19731ae1f639bdaa1ce6cde23a71bca9029da979bbf1274f553",
+                            "0x71afd498d0000",
+                            "0x0"
+                        ],
+                        "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 47,
+                            "n_steps": 540
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "DELEGATE",
+                                "calldata": [
+                                    "0x3be62320d24b19731ae1f639bdaa1ce6cde23a71bca9029da979bbf1274f553",
+                                    "0x71afd498d0000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                                "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 21
+                                    },
+                                    "n_memory_holes": 44,
+                                    "n_steps": 480
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1"
+                        ],
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x56d1a3c0a6a1510be8af1dcce2a9da7919d31a59625aab5ebaab000c03bccc5",
+                "0x764882bdf3748acf5c3a707a074c0fbd4b93babeb0f9fdd640c610766ed6412"
+            ],
+            "transaction_hash": "0x6d279fe1c9cfb0540d527dec02a0c2b6f1417e91f00084b34e9c63bca0b28a8"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x95d72e3f1721a9ba59faea814da8f2077c8895aa7280d3fd285424407a10b9"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0xc6529e402abdc91cc51f61ae71df2337bc6c535fd96eb79235b1a32bbc6fdc",
+                "contract_address": "0x68ec88a263824a080743092facd2728c8f7c727c29551b455764560b7f4835f",
+                "entry_point_type": "CONSTRUCTOR",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 0,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 0
+                    },
+                    "n_memory_holes": 0,
+                    "n_steps": 41
+                },
+                "internal_calls": [],
+                "messages": [],
+                "result": [],
+                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+            },
+            "signature": [],
+            "transaction_hash": "0xbd418c0c10dcd5502df78d79b4d268831354f8b4b4dc7eee88b961323dffff"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x2",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x3276861cf5e05d6daf8f352cabb47df623eb10c383ab742fcc7abea94d5c5cc",
+                    "0x3",
+                    "0x9",
+                    "0xc",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x6c6b935b8bbd400000",
+                    "0x0",
+                    "0x6c6b935b8bbd400000",
+                    "0x0",
+                    "0x7b6693c",
+                    "0x0",
+                    "0x2",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                    "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                    "0x62adee95",
+                    "0x1"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 22,
+                        "range_check_builtin": 582
+                    },
+                    "n_memory_holes": 233,
+                    "n_steps": 8585
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x2",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x3276861cf5e05d6daf8f352cabb47df623eb10c383ab742fcc7abea94d5c5cc",
+                            "0x3",
+                            "0x9",
+                            "0xc",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x6c6b935b8bbd400000",
+                            "0x0",
+                            "0x6c6b935b8bbd400000",
+                            "0x0",
+                            "0x7b6693c",
+                            "0x0",
+                            "0x2",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                            "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                            "0x62adee95",
+                            "0x1"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x3f094122db852d07214fa15f38ec2bdd57452dc6f35091cc249cad3a661c5e4",
+                                    "0x6",
+                                    "0x1",
+                                    "0x2",
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0",
+                                    "0x7c0487c",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 2
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 22,
+                                "range_check_builtin": 582
+                            },
+                            "n_memory_holes": 210,
+                            "n_steps": 8525
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 139
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0",
+                                    "0x7b6693c",
+                                    "0x0",
+                                    "0x2",
+                                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                    "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                    "0x62adee95"
+                                ],
+                                "caller_address": "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 20,
+                                        "range_check_builtin": 573
+                                    },
+                                    "n_memory_holes": 185,
+                                    "n_steps": 7850
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 0,
+                                                "range_check_builtin": 0
+                                            },
+                                            "n_memory_holes": 0,
+                                            "n_steps": 133
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x48fa669fa2b2a5846d76f7d",
+                                            "0x0",
+                                            "0x53ba68e75405",
+                                            "0x0",
+                                            "0x62ade12a"
+                                        ],
+                                        "selector": "0x3cb0e1486e633fbe3e2fafe8aedf12b70ca1860e7467ddb75a17858cde39312"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                            "0x6c6b935b8bbd400000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                        "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 774
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x0",
+                                            "0x0",
+                                            "0x7c0487c",
+                                            "0x0",
+                                            "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x48fa6d665be85e404176f7d",
+                                                    "0x0",
+                                                    "0x53ba61270b89",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                ],
+                                                "order": 0
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0x6c6b935b8bbd400000",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x7c0487c",
+                                                    "0x0",
+                                                    "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31"
+                                                ],
+                                                "keys": [
+                                                    "0xe316f0d9d2a3affa97de1d99bb2aac0538e2666d0d8545545ead241ef0ccab"
+                                                ],
+                                                "order": 1
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 6,
+                                                "range_check_builtin": 339
+                                            },
+                                            "n_memory_holes": 69,
+                                            "n_steps": 4274
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x77f7da9e66e2936f8d827cacca4b70cf68846e13d55e273c9abbe09b3ca31",
+                                                    "0x7c0487c",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 21
+                                                    },
+                                                    "n_memory_holes": 40,
+                                                    "n_steps": 489
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                                ],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 96
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x48fa6d665be85e404176f7d",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733"
+                                                ],
+                                                "caller_address": "0x4b05cce270364e2e4bf65bde3e9429b50c97ea3443b133442f838045f41e733",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 96
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x53ba61270b89",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [],
+                                        "selector": "0x15543c3708653cda9d418b4ccd3be11368e40636c10c44b18cfe756b6d88b29"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x2",
+                                    "0x6c6b935b8bbd400000",
+                                    "0x0",
+                                    "0x7c0487c",
+                                    "0x0"
+                                ],
+                                "selector": "0x3276861cf5e05d6daf8f352cabb47df623eb10c383ab742fcc7abea94d5c5cc"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x2",
+                            "0x6c6b935b8bbd400000",
+                            "0x0",
+                            "0x7c0487c",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x2",
+                    "0x6c6b935b8bbd400000",
+                    "0x0",
+                    "0x7c0487c",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x79db56ce6f6a8cc7857e3746fdaddcd07777a25d78b7b2fe28a28cbe5bdd0e8",
+                "0x5d20b4ed2545dc80b07edfa97ae56350e0e727039d206e070b665dc68b932d6"
+            ],
+            "transaction_hash": "0x3f094122db852d07214fa15f38ec2bdd57452dc6f35091cc249cad3a661c5e4"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                    "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463",
+                    "0x2",
+                    "0x31ed2f2c72f06f3bc44a33871d7e40645b3266709849b40309e5ce6293bdab8",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x3deacd13a904378b60adfdc6be027071485db7cfc31adcf7b2f6e64dc8b38f0",
+                "entry_point_type": "CONSTRUCTOR",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 0,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 1
+                    },
+                    "n_memory_holes": 2,
+                    "n_steps": 219
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x31ed2f2c72f06f3bc44a33871d7e40645b3266709849b40309e5ce6293bdab8",
+                            "0x0"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x3deacd13a904378b60adfdc6be027071485db7cfc31adcf7b2f6e64dc8b38f0",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x3deacd13a904378b60adfdc6be027071485db7cfc31adcf7b2f6e64dc8b38f0",
+                                    "0x31ed2f2c72f06f3bc44a33871d7e40645b3266709849b40309e5ce6293bdab8",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x10c19bef19acd19b2c9f4caa40fd47c9fbe1d9f91324d44dcd36be2dae96784"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 0,
+                                "range_check_builtin": 0
+                            },
+                            "n_memory_holes": 0,
+                            "n_steps": 141
+                        },
+                        "internal_calls": [],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x79dc0da7c54b95f10aa182ad0a46400db63156920adb65eca2654c0945a463"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+            },
+            "signature": [],
+            "transaction_hash": "0x5c3f43c0c65b3bcd663a2999a9fbb6550fa3aa78c6d92d2f30cee072a02b72b"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x4",
+                    "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                    "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x0",
+                    "0x3",
+                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                    "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x3",
+                    "0x3",
+                    "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                    "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x6",
+                    "0x3",
+                    "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                    "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x9",
+                    "0x3",
+                    "0xc",
+                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                    "0x3635c9adc5dea00000",
+                    "0x0",
+                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                    "0x3b9aca00",
+                    "0x0",
+                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                    "0x3635c9adc5dea00000",
+                    "0x0",
+                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                    "0x3635c9adc5dea00000",
+                    "0x0",
+                    "0x19"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 8,
+                        "range_check_builtin": 52
+                    },
+                    "n_memory_holes": 134,
+                    "n_steps": 1861
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x4",
+                            "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                            "0x0",
+                            "0x3",
+                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                            "0x3",
+                            "0x3",
+                            "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                            "0x6",
+                            "0x3",
+                            "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                            "0x9",
+                            "0x3",
+                            "0xc",
+                            "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                            "0x3635c9adc5dea00000",
+                            "0x0",
+                            "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                            "0x3b9aca00",
+                            "0x0",
+                            "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                            "0x3635c9adc5dea00000",
+                            "0x0",
+                            "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                            "0x3635c9adc5dea00000",
+                            "0x0",
+                            "0x19"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x311b496d373b0776b1f12cd500138f228af8f45664530116bc501a6e2f4b40f",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 8,
+                                "range_check_builtin": 52
+                            },
+                            "n_memory_holes": 103,
+                            "n_steps": 1801
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                    "0x3635c9adc5dea00000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x4bc8ac16658025bff4a3bd0760e84fcf075417a4c55c6fae716efdd8f1ed26c",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 12
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                    "0x3b9aca00",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 12
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                    "0x3635c9adc5dea00000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x24da028e8176afd3219fbeafb17c49624af9b86dcbe81007ae40d93f741617d",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 12
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                    "0x3635c9adc5dea00000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x1b933cf37bd92a05483d1d6633c644bb91e94c577191d1296cf4ad3da09c0fa",
+                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                "contract_address": "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 12
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x5d58cfd3310f31fced733546124bb04b939e5ea62c9ee7f43293f3f2141dc78",
+                "0x5b40f893ff841d21ae9091cc73fa7ffe16fb59fba4426264df69293222f5d3c"
+            ],
+            "transaction_hash": "0x311b496d373b0776b1f12cd500138f228af8f45664530116bc501a6e2f4b40f"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x2f13075210b7252c826eafdc09d9d77ef272f582947f7adbd44ef79eae0062c",
+                    "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x68747470733a2f2f6d696e747371756172652e6d7970696e6174612e636c6f",
+                    "0x75642f697066732f516d623254585537357352654355506d38467444583659",
+                    "0x35527744775066784d74314d4a70647a6b6a5537413468",
+                    "0xb"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x1e4e4dbe3eec72b29450b3995b297f4afdb187aa1b3916d32c64eaf74d79c03",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 18,
+                        "range_check_builtin": 46
+                    },
+                    "n_memory_holes": 120,
+                    "n_steps": 1574
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x2f13075210b7252c826eafdc09d9d77ef272f582947f7adbd44ef79eae0062c",
+                            "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x68747470733a2f2f6d696e747371756172652e6d7970696e6174612e636c6f",
+                            "0x75642f697066732f516d623254585537357352654355506d38467444583659",
+                            "0x35527744775066784d74314d4a70647a6b6a5537413468",
+                            "0xb"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x1e4e4dbe3eec72b29450b3995b297f4afdb187aa1b3916d32c64eaf74d79c03",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x3e83a229f544b538f9bf4b79860edcabfe3a2de02b5cb7ff11a8c76666c0fa7",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 1
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 18,
+                                "range_check_builtin": 46
+                            },
+                            "n_memory_holes": 110,
+                            "n_steps": 1514
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x68747470733a2f2f6d696e747371756172652e6d7970696e6174612e636c6f",
+                                    "0x75642f697066732f516d623254585537357352654355506d38467444583659",
+                                    "0x35527744775066784d74314d4a70647a6b6a5537413468"
+                                ],
+                                "caller_address": "0x1e4e4dbe3eec72b29450b3995b297f4afdb187aa1b3916d32c64eaf74d79c03",
+                                "class_hash": "0x56fc31380fa370daa13e55eafb65b6ff95e7d0a451eb5bf66086f70f2399f0f",
+                                "contract_address": "0x2f13075210b7252c826eafdc09d9d77ef272f582947f7adbd44ef79eae0062c",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [
+                                    {
+                                        "data": [
+                                            "0x0",
+                                            "0x1e4e4dbe3eec72b29450b3995b297f4afdb187aa1b3916d32c64eaf74d79c03",
+                                            "0x7ff8",
+                                            "0x0"
+                                        ],
+                                        "keys": [
+                                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                        ],
+                                        "order": 0
+                                    }
+                                ],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 18,
+                                        "range_check_builtin": 42
+                                    },
+                                    "n_memory_holes": 104,
+                                    "n_steps": 1122
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x423ade0fdac515ab3ee10bff249a2849739f72e235727e1f31ce4ea11a199e2",
+                "0x44b2ef39efc0e0e3915d7ef8de65ca2b7795fc25413d1e7dd03fcbd6f52db2d"
+            ],
+            "transaction_hash": "0x3e83a229f544b538f9bf4b79860edcabfe3a2de02b5cb7ff11a8c76666c0fa7"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                    "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x1312d00",
+                    "0x0",
+                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                    "0x27"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 17,
+                        "range_check_builtin": 881
+                    },
+                    "n_memory_holes": 177,
+                    "n_steps": 10939
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                            "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x1312d00",
+                            "0x0",
+                            "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                            "0x27"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x1d808749d0a008d6cea1d48197251ab4194df154984c20b39e638af78aa2a1b",
+                                    "0x2",
+                                    "0x35ab060f27e60e175e",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 7
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 17,
+                                "range_check_builtin": 881
+                            },
+                            "n_memory_holes": 167,
+                            "n_steps": 10879
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1312d00",
+                                    "0x0",
+                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463"
+                                ],
+                                "caller_address": "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                "class_hash": "0x61cad333ef494162645f37e3ba0cafe40998c0475c3c3cc1bbb6c5cdb7d2765",
+                                "contract_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 17,
+                                        "range_check_builtin": 877
+                                    },
+                                    "n_memory_holes": 161,
+                                    "n_steps": 10461
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0x1312d00",
+                                            "0x0",
+                                            "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463"
+                                        ],
+                                        "caller_address": "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                        "class_hash": "0x65152b0ce5de2ea2a92dc1bbe64ab080172f0294567653c8d45626623bfccaf",
+                                        "contract_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xc186c011688ee049ea75dcc9871ac2c4ba4f3caf7418c724f224c1ed287c44"
+                                                ],
+                                                "order": 0
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x4adfdb51",
+                                                    "0x0",
+                                                    "0x942",
+                                                    "0x0",
+                                                    "0xe071d000d03c1bf",
+                                                    "0x0",
+                                                    "0x671dbdb87",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x188f8a3c3c1ecd506fa6cc68db19877c776131b50c0f9b64460e6f23f491507"
+                                                ],
+                                                "order": 1
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x0",
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x35ab060f27e60e175e",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                ],
+                                                "order": 3
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x1312d00",
+                                                    "0x0",
+                                                    "0x35ab060f27e60e175e",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x3a482ae5c73f902879174aee693bf807fd6efe8575a1b5c08cc80f4bd2c9761"
+                                                ],
+                                                "order": 4
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x35ab060f27e60e175e",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xfddc638e1f5f71961eca301d6193c838f86055357a33ca1dcdb8149c5af612"
+                                                ],
+                                                "order": 5
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x1312d00",
+                                                    "0x0",
+                                                    "0x35ab060f27e60e175e",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x9149d2123147c5f43d258257fef0b7b969db78269369ebcf5ebb9eef8592f2"
+                                                ],
+                                                "order": 6
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 17,
+                                                "range_check_builtin": 877
+                                            },
+                                            "n_memory_holes": 158,
+                                            "n_steps": 10406
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 101
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x4adfdb51",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4adfdb51",
+                                                    "0x0",
+                                                    "0x671dbd245",
+                                                    "0x0",
+                                                    "0x0",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x19f1904f349c80f2eb895ad80b40d016cefb290a3d23eaee37a9aebf0cbce2c",
+                                                "contract_address": "0x1a5a5f2234d8bb79eff564d6285a29be5b4c773066617377ffd200cbfe03ba8",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 226
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 2104
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x6051b483",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x3ebb8e1a25e02ab3232ec50551ef4feec907c5d845d9f53ee8b61baf1dfce54"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x1312d00",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x61cad333ef494162645f37e3ba0cafe40998c0475c3c3cc1bbb6c5cdb7d2765",
+                                                "contract_address": "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 6
+                                                    },
+                                                    "n_memory_holes": 24,
+                                                    "n_steps": 253
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "DELEGATE",
+                                                        "calldata": [
+                                                            "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                            "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                            "0x1312d00",
+                                                            "0x0"
+                                                        ],
+                                                        "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                        "class_hash": "0x759b7132014837172c72c97088c7b6f7e907fc880796ccaac978cdb90336de8",
+                                                        "contract_address": "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 2,
+                                                                "range_check_builtin": 6
+                                                            },
+                                                            "n_memory_holes": 20,
+                                                            "n_steps": 198
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [
+                                                            "0x1"
+                                                        ],
+                                                        "selector": "0x2e702d588ea58c59286befec02c787504e2f8dd646f9a2e0d5db92f73fdb150"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x2e702d588ea58c59286befec02c787504e2f8dd646f9a2e0d5db92f73fdb150"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 101
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x4adfdb51",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 101
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x4adfdb51",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                    "0x1312d00",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [
+                                                    {
+                                                        "data": [
+                                                            "0x38975ad3e54176ea815d3a5ca3055b926ffac4cf70257cb3c258ba39d020463",
+                                                            "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                            "0x1312d00",
+                                                            "0x0"
+                                                        ],
+                                                        "keys": [
+                                                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                        ],
+                                                        "order": 2
+                                                    }
+                                                ],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 8,
+                                                        "range_check_builtin": 32
+                                                    },
+                                                    "n_memory_holes": 62,
+                                                    "n_steps": 818
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 101
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x4c110851",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f"
+                                                ],
+                                                "caller_address": "0x4ffdb1f2f51afa786bb30d547e5584ffba69e89f204973c03a98c58b9cf961f",
+                                                "class_hash": "0x663344fcfd76f5bb6dffaa1aa08c97dc54c9c2774828091f18d0a4706cb2a5e",
+                                                "contract_address": "0xcf1f2891ce07dfff3fa1828b5c4cc01ccc603876b913d9e6fc89bad276ba7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 10,
+                                                    "n_steps": 101
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x4c110851",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x35ab060f27e60e175e",
+                                            "0x0"
+                                        ],
+                                        "selector": "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x35ab060f27e60e175e",
+                                    "0x0"
+                                ],
+                                "selector": "0xc73f681176fc7b3f9693986fd7b14581e8d540519e27400e88b8713932be01"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x35ab060f27e60e175e",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x35ab060f27e60e175e",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x37d49e4a913a87c4426998120ddea237f386580cc79c584fd7e021c242adade",
+                "0x3aeffbf9315d9bb166a39c92147a87a257af74e37fb62a46c3077c045f6721a"
+            ],
+            "transaction_hash": "0x1d808749d0a008d6cea1d48197251ab4194df154984c20b39e638af78aa2a1b"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x39",
+                    "0x39",
+                    "0xe",
+                    "0x6274632f757364",
+                    "0x40eb84accabcbc00000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6574682f757364",
+                    "0x361f95564006000000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x736f6c2f757364",
+                    "0x1a1a6eb0cc3618000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x617661782f757364",
+                    "0xd178a9074fbf0000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x646f67652f757364",
+                    "0xbf16896a362800",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x736869622f757364",
+                    "0x72d08a5b400",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6461692f757364",
+                    "0xddfa5da75f54000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x757364742f757364",
+                    "0xddc185bd12ec000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6274632f7573642d3230323230363234",
+                    "0x40c47caaf175f400000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6274632f7573642d3230323230393330",
+                    "0x4125a1a9db09b000000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6274632f7573642d3230323231323330",
+                    "0x41b9f34a7b16ac00000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6574682f7573642d3230323230363234",
+                    "0x361e3210c7a8760000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6574682f7573642d3230323230393330",
+                    "0x363cba091fb2520000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0x6574682f7573642d3230323231323330",
+                    "0x365718310ea3900000",
+                    "0x62ade107",
+                    "0x706f6e7469732d667478",
+                    "0xc459"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 266,
+                        "range_check_builtin": 760
+                    },
+                    "n_memory_holes": 2524,
+                    "n_steps": 22715
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0xe",
+                            "0x6274632f757364",
+                            "0x40eb84accabcbc00000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6574682f757364",
+                            "0x361f95564006000000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x736f6c2f757364",
+                            "0x1a1a6eb0cc3618000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x617661782f757364",
+                            "0xd178a9074fbf0000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x646f67652f757364",
+                            "0xbf16896a362800",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x736869622f757364",
+                            "0x72d08a5b400",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6461692f757364",
+                            "0xddfa5da75f54000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x757364742f757364",
+                            "0xddc185bd12ec000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6274632f7573642d3230323230363234",
+                            "0x40c47caaf175f400000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6274632f7573642d3230323230393330",
+                            "0x4125a1a9db09b000000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6274632f7573642d3230323231323330",
+                            "0x41b9f34a7b16ac00000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6574682f7573642d3230323230363234",
+                            "0x361e3210c7a8760000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6574682f7573642d3230323230393330",
+                            "0x363cba091fb2520000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478",
+                            "0x6574682f7573642d3230323231323330",
+                            "0x365718310ea3900000",
+                            "0x62ade107",
+                            "0x706f6e7469732d667478"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x40eb84accabcbc00000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x361f95564006000000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x736f6c2f757364",
+                                    "0x1a1a6eb0cc3618000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x617661782f757364",
+                                    "0xd178a9074fbf0000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            },
+                            {
+                                "data": [
+                                    "0x646f67652f757364",
+                                    "0xbf16896a362800",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 4
+                            },
+                            {
+                                "data": [
+                                    "0x736869622f757364",
+                                    "0x72d08a5b400",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 5
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xddfa5da75f54000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 6
+                            },
+                            {
+                                "data": [
+                                    "0x757364742f757364",
+                                    "0xddc185bd12ec000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 7
+                            },
+                            {
+                                "data": [
+                                    "0x6274632f7573642d3230323230363234",
+                                    "0x40c47caaf175f400000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 8
+                            },
+                            {
+                                "data": [
+                                    "0x6274632f7573642d3230323230393330",
+                                    "0x4125a1a9db09b000000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 9
+                            },
+                            {
+                                "data": [
+                                    "0x6274632f7573642d3230323231323330",
+                                    "0x41b9f34a7b16ac00000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 10
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f7573642d3230323230363234",
+                                    "0x361e3210c7a8760000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 11
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f7573642d3230323230393330",
+                                    "0x363cba091fb2520000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 12
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f7573642d3230323231323330",
+                                    "0x365718310ea3900000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 13
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 266,
+                                "range_check_builtin": 757
+                            },
+                            "n_memory_holes": 2464,
+                            "n_steps": 22448
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x40eb84accabcbc00000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x361f95564006000000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736f6c2f757364",
+                                    "0x1a1a6eb0cc3618000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x617661782f757364",
+                                    "0xd178a9074fbf0000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x646f67652f757364",
+                                    "0xbf16896a362800",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736869622f757364",
+                                    "0x72d08a5b400",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xddfa5da75f54000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364742f757364",
+                                    "0xddc185bd12ec000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f7573642d3230323230363234",
+                                    "0x40c47caaf175f400000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f7573642d3230323230393330",
+                                    "0x4125a1a9db09b000000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f7573642d3230323231323330",
+                                    "0x41b9f34a7b16ac00000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f7573642d3230323230363234",
+                                    "0x361e3210c7a8760000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f7573642d3230323230393330",
+                                    "0x363cba091fb2520000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f7573642d3230323231323330",
+                                    "0x365718310ea3900000",
+                                    "0x62ade107",
+                                    "0x706f6e7469732d667478"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x6f289f3ef32facea4ea95d7bd3c3b40b31b5f8a46cd0f6277d2cc6e4813cf4c",
+                "0x7510b44750a1307d6bbbf9748f7e54833e7bf42ed8a490458d58b1dec3e76b7"
+            ],
+            "transaction_hash": "0xb67cc869b35e043c07a74612c531afd7827ce4fb4f3d9d1c8e25b934feb991"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                    "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x32bdd4612a400f07afed9d29547fd9522e34d880b01b00b56bf74b04ce6faa3",
+                    "0x71afd498d0000",
+                    "0x0",
+                    "0x593b87b8f407deb3c26af6fc9f7b1017f612fb4fbd0faf66e771f177ecf633"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x623ce5111775ec86d96652d4c9d83f83e91b76b7bc51d62ea69134b8675e0f1",
+                "contract_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 6,
+                        "range_check_builtin": 29
+                    },
+                    "n_memory_holes": 73,
+                    "n_steps": 853
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x32bdd4612a400f07afed9d29547fd9522e34d880b01b00b56bf74b04ce6faa3",
+                            "0x71afd498d0000",
+                            "0x0"
+                        ],
+                        "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                        "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 4,
+                                "range_check_builtin": 21
+                            },
+                            "n_memory_holes": 47,
+                            "n_steps": 540
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "DELEGATE",
+                                "calldata": [
+                                    "0x32bdd4612a400f07afed9d29547fd9522e34d880b01b00b56bf74b04ce6faa3",
+                                    "0x71afd498d0000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x17239d35be9e3a622b01677fff06c05ea7d926b94f864e59188d1a7eca00b1f",
+                                "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 21
+                                    },
+                                    "n_memory_holes": 44,
+                                    "n_steps": 480
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1"
+                        ],
+                        "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x3ffad9b32de4ed8a7d544c44971cb7631b3ba140ef129b4ccda204cd01d8a17",
+                "0x2d64a664b29686470bb8bf994414eee1ec51dab7e2ed4d0fe652870d9db4abd"
+            ],
+            "transaction_hash": "0x2da9cad86f76f406a10f2b4878b108a02f49e0d749abdadec030d42bc8c2f54"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x3",
+                    "0x2a844fa9872228579fafc521f377015d8a0fc7438746638eed8c9cf863fef78",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0xe417692a0bd68d7014ed8283cfbbc5e15cd955c95644607a023c4d433839a3",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x3",
+                    "0x3",
+                    "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                    "0x3f35dbce7a07ce455b128890d383c554afbc1b07cf7390a13e2d602a38c1a0a",
+                    "0x6",
+                    "0x6",
+                    "0xc",
+                    "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                    "0x1158e460913d00000",
+                    "0x0",
+                    "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                    "0x14410afb4f5a14fa0",
+                    "0x0",
+                    "0x1158e460913d00000",
+                    "0x0",
+                    "0x125963497142155dc",
+                    "0x0",
+                    "0x14410afb4f5a14fa0",
+                    "0x0",
+                    "0x13"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 24,
+                        "range_check_builtin": 251
+                    },
+                    "n_memory_holes": 222,
+                    "n_steps": 4630
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x3",
+                            "0x2a844fa9872228579fafc521f377015d8a0fc7438746638eed8c9cf863fef78",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0xe417692a0bd68d7014ed8283cfbbc5e15cd955c95644607a023c4d433839a3",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x3",
+                            "0x3",
+                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                            "0x3f35dbce7a07ce455b128890d383c554afbc1b07cf7390a13e2d602a38c1a0a",
+                            "0x6",
+                            "0x6",
+                            "0xc",
+                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                            "0x1158e460913d00000",
+                            "0x0",
+                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                            "0x14410afb4f5a14fa0",
+                            "0x0",
+                            "0x1158e460913d00000",
+                            "0x0",
+                            "0x125963497142155dc",
+                            "0x0",
+                            "0x14410afb4f5a14fa0",
+                            "0x0",
+                            "0x13"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x577e8a98102dbe78e744dcff17cae0d9832a25f4daf7485c2a070741e2fb9c",
+                                    "0x4",
+                                    "0x1",
+                                    "0x1",
+                                    "0x1270e6723177cdc84",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 2
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 24,
+                                "range_check_builtin": 251
+                            },
+                            "n_memory_holes": 195,
+                            "n_steps": 4570
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                    "0x1158e460913d00000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                "contract_address": "0x2a844fa9872228579fafc521f377015d8a0fc7438746638eed8c9cf863fef78",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 138
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                    "0x14410afb4f5a14fa0",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                "contract_address": "0xe417692a0bd68d7014ed8283cfbbc5e15cd955c95644607a023c4d433839a3",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 5
+                                    },
+                                    "n_memory_holes": 10,
+                                    "n_steps": 138
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1158e460913d00000",
+                                    "0x0",
+                                    "0x125963497142155dc",
+                                    "0x0",
+                                    "0x14410afb4f5a14fa0",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                "class_hash": "0x6d05d50914317d99c39b39f6c2b6a847955140264c4ad8ab0deb95eb7647f4f",
+                                "contract_address": "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [
+                                    {
+                                        "data": [
+                                            "0x0",
+                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                            "0x1270e6723177cdc84",
+                                            "0x0"
+                                        ],
+                                        "keys": [
+                                            "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                        ],
+                                        "order": 0
+                                    },
+                                    {
+                                        "data": [
+                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                            "0x1158e460913d00000",
+                                            "0x0",
+                                            "0x14270b660d942a6c3",
+                                            "0x0",
+                                            "0x1270e6723177cdc84",
+                                            "0x0"
+                                        ],
+                                        "keys": [
+                                            "0x2cfb12ff9e08412ec5009c65ea06e727119ad948d25c8a8cc2c86fec4adee70"
+                                        ],
+                                        "order": 1
+                                    }
+                                ],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 20,
+                                        "range_check_builtin": 237
+                                    },
+                                    "n_memory_holes": 160,
+                                    "n_steps": 3712
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad"
+                                        ],
+                                        "caller_address": "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                        "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                        "contract_address": "0x2a844fa9872228579fafc521f377015d8a0fc7438746638eed8c9cf863fef78",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 1,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 95
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0xd7dd7e49bb326a850d58",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad"
+                                        ],
+                                        "caller_address": "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                        "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                        "contract_address": "0xe417692a0bd68d7014ed8283cfbbc5e15cd955c95644607a023c4d433839a3",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 1,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 10,
+                                            "n_steps": 95
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0xfac6068ce4af950e28fe",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                            "0x1158e460913d00000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                        "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                        "contract_address": "0x2a844fa9872228579fafc521f377015d8a0fc7438746638eed8c9cf863fef78",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 773
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                            "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                            "0x14270b660d942a6c3",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x37e502802a8dc06b509651f1ccc0ba09064947a4afb0f3ece45b6525f9611ad",
+                                        "class_hash": "0xc7b6a624c8a846902c8a645abab35c030e93e138eccfaa7d2b702fa9aae824",
+                                        "contract_address": "0xe417692a0bd68d7014ed8283cfbbc5e15cd955c95644607a023c4d433839a3",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 32
+                                            },
+                                            "n_memory_holes": 60,
+                                            "n_steps": 773
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x1270e6723177cdc84",
+                                    "0x0"
+                                ],
+                                "selector": "0x3f35dbce7a07ce455b128890d383c554afbc1b07cf7390a13e2d602a38c1a0a"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x1",
+                            "0x1270e6723177cdc84",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1",
+                    "0x1270e6723177cdc84",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x2f36f0aa515e69feb383cef172693b6f0a46ee9479f7774e5fa10be147ea17a",
+                "0xe92a1b824720c5e1d6a99c7dcf3d70238c5310ea618cb0ff5fae474b77f4eb"
+            ],
+            "transaction_hash": "0x577e8a98102dbe78e744dcff17cae0d9832a25f4daf7485c2a070741e2fb9c"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x29",
+                    "0x29",
+                    "0xa",
+                    "0x6274632f757364",
+                    "0x40ef130ecf2c6c00000",
+                    "0x62ade117",
+                    "0x706f6e7469732d636578",
+                    "0x6574682f757364",
+                    "0x3629da585453ca0000",
+                    "0x62ade117",
+                    "0x706f6e7469732d636578",
+                    "0x736f6c2f757364",
+                    "0x1a36e0552371bc000",
+                    "0x62ade117",
+                    "0x706f6e7469732d636578",
+                    "0x617661782f757364",
+                    "0xd23826cb0123c000",
+                    "0x62ade117",
+                    "0x706f6e7469732d636578",
+                    "0x646f67652f757364",
+                    "0xbfd8b6c1df0000",
+                    "0x62ade118",
+                    "0x706f6e7469732d636578",
+                    "0x736869622f757364",
+                    "0x731b0bd7c00",
+                    "0x62ade119",
+                    "0x706f6e7469732d636578",
+                    "0x6461692f757364",
+                    "0xde4fa186d1f0080",
+                    "0x62ade119",
+                    "0x706f6e7469732d636578",
+                    "0x757364742f757364",
+                    "0xddeeff45500c000",
+                    "0x62ade119",
+                    "0x706f6e7469732d636578",
+                    "0x757364632f757364",
+                    "0xde3e93f3bb03f80",
+                    "0x62ade11a",
+                    "0x706f6e7469732d636578",
+                    "0x747573642f757364",
+                    "0xde3e93f3bb03f80",
+                    "0x62ade11a",
+                    "0x706f6e7469732d636578",
+                    "0xc45a"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 190,
+                        "range_check_builtin": 544
+                    },
+                    "n_memory_holes": 1808,
+                    "n_steps": 16303
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0xa",
+                            "0x6274632f757364",
+                            "0x40ef130ecf2c6c00000",
+                            "0x62ade117",
+                            "0x706f6e7469732d636578",
+                            "0x6574682f757364",
+                            "0x3629da585453ca0000",
+                            "0x62ade117",
+                            "0x706f6e7469732d636578",
+                            "0x736f6c2f757364",
+                            "0x1a36e0552371bc000",
+                            "0x62ade117",
+                            "0x706f6e7469732d636578",
+                            "0x617661782f757364",
+                            "0xd23826cb0123c000",
+                            "0x62ade117",
+                            "0x706f6e7469732d636578",
+                            "0x646f67652f757364",
+                            "0xbfd8b6c1df0000",
+                            "0x62ade118",
+                            "0x706f6e7469732d636578",
+                            "0x736869622f757364",
+                            "0x731b0bd7c00",
+                            "0x62ade119",
+                            "0x706f6e7469732d636578",
+                            "0x6461692f757364",
+                            "0xde4fa186d1f0080",
+                            "0x62ade119",
+                            "0x706f6e7469732d636578",
+                            "0x757364742f757364",
+                            "0xddeeff45500c000",
+                            "0x62ade119",
+                            "0x706f6e7469732d636578",
+                            "0x757364632f757364",
+                            "0xde3e93f3bb03f80",
+                            "0x62ade11a",
+                            "0x706f6e7469732d636578",
+                            "0x747573642f757364",
+                            "0xde3e93f3bb03f80",
+                            "0x62ade11a",
+                            "0x706f6e7469732d636578"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x40ef130ecf2c6c00000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x3629da585453ca0000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x736f6c2f757364",
+                                    "0x1a36e0552371bc000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x617661782f757364",
+                                    "0xd23826cb0123c000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            },
+                            {
+                                "data": [
+                                    "0x646f67652f757364",
+                                    "0xbfd8b6c1df0000",
+                                    "0x62ade118",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 4
+                            },
+                            {
+                                "data": [
+                                    "0x736869622f757364",
+                                    "0x731b0bd7c00",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 5
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xde4fa186d1f0080",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 6
+                            },
+                            {
+                                "data": [
+                                    "0x757364742f757364",
+                                    "0xddeeff45500c000",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 7
+                            },
+                            {
+                                "data": [
+                                    "0x757364632f757364",
+                                    "0xde3e93f3bb03f80",
+                                    "0x62ade11a",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 8
+                            },
+                            {
+                                "data": [
+                                    "0x747573642f757364",
+                                    "0xde3e93f3bb03f80",
+                                    "0x62ade11a",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 9
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 190,
+                                "range_check_builtin": 541
+                            },
+                            "n_memory_holes": 1764,
+                            "n_steps": 16036
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x40ef130ecf2c6c00000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x3629da585453ca0000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736f6c2f757364",
+                                    "0x1a36e0552371bc000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x617661782f757364",
+                                    "0xd23826cb0123c000",
+                                    "0x62ade117",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x646f67652f757364",
+                                    "0xbfd8b6c1df0000",
+                                    "0x62ade118",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736869622f757364",
+                                    "0x731b0bd7c00",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xde4fa186d1f0080",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364742f757364",
+                                    "0xddeeff45500c000",
+                                    "0x62ade119",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364632f757364",
+                                    "0xde3e93f3bb03f80",
+                                    "0x62ade11a",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x747573642f757364",
+                                    "0xde3e93f3bb03f80",
+                                    "0x62ade11a",
+                                    "0x706f6e7469732d636578"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x5cc433a5d87edc5829494303ba60ef5c7177cda579e13739e65c590d80dc6c4",
+                "0x35c9c7779a7d2d0be10286865f518b742c96ced6ac686824cebf556097fd94a"
+            ],
+            "transaction_hash": "0x6775350096f21c08fafa84ac75170ea98a8c1fdb6548ca8ad951ff9a5abb923"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0xc3511006c04ef1d78af4c8e0e74ec18a6e64ff9e",
+                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                    "0x38d7ea4c68000",
+                    "0x0"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                "entry_point_type": "L1_HANDLER",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 0,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 2,
+                        "range_check_builtin": 12
+                    },
+                    "n_memory_holes": 27,
+                    "n_steps": 635
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0xc3511006c04ef1d78af4c8e0e74ec18a6e64ff9e",
+                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                            "0x38d7ea4c68000",
+                            "0x0"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x339e704d3ae446abefd8ed572bc497d403dfc77a891838d5a4c3aa4b3d8dcf2",
+                        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                        "entry_point_type": "L1_HANDLER",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                    "0x38d7ea4c68000",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x221e5a5008f7a28564f0eaa32cdeb0848d10657c449aed3e15d12150a7c2db3"
+                                ],
+                                "order": 0
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 2,
+                                "range_check_builtin": 12
+                            },
+                            "n_memory_holes": 23,
+                            "n_steps": 571
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                    "0x38d7ea4c68000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 12
+                                    },
+                                    "n_memory_holes": 23,
+                                    "n_steps": 416
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0x7de33651a7587e088241ad98021c02361cfcabc7d2f28e4c7dd7d65b3ca43de",
+                                            "0x38d7ea4c68000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                        "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 12
+                                            },
+                                            "n_memory_holes": 20,
+                                            "n_steps": 356
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [],
+                                        "selector": "0x151e58b29179122a728eab07c8847e5baf5802379c5db3a7d57a8263a7bd1d"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x151e58b29179122a728eab07c8847e5baf5802379c5db3a7d57a8263a7bd1d"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x2d757788a8d8d6f21d1cd40bce38a8222d70654214e96ff95d8086e684fbee5"
+            },
+            "signature": [],
+            "transaction_hash": "0x53787fbf6680150741163cf2406c2a1710de4cc6c6079d978081ff94156002b"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                    "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688",
+                    "0x0",
+                    "0x1d",
+                    "0x1d",
+                    "0x7",
+                    "0x6274632f757364",
+                    "0x40e8e85219e66000000",
+                    "0x62ade11c",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x6574682f757364",
+                    "0x36112683c29f980000",
+                    "0x62ade11c",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x617661782f757364",
+                    "0xd1caba5b2e0ec000",
+                    "0x62ade11c",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x736869622f757364",
+                    "0x723b87623ff",
+                    "0x62ade11b",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x6461692f757364",
+                    "0xddc2a8c6e140000",
+                    "0x62ade11d",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x757364742f757364",
+                    "0xddc45d5596be000",
+                    "0x62ade11e",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0x757364632f757364",
+                    "0xde1fe1eaf827f80",
+                    "0x62ade11e",
+                    "0x706f6e7469732d6269747374616d70",
+                    "0xc45b"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x493af3546940eb96471cf95ae3a5aa1286217b07edd1e12d00143010ca904b1",
+                "contract_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 133,
+                        "range_check_builtin": 382
+                    },
+                    "n_memory_holes": 1265,
+                    "n_steps": 11506
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [
+                            "0x7",
+                            "0x6274632f757364",
+                            "0x40e8e85219e66000000",
+                            "0x62ade11c",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x6574682f757364",
+                            "0x36112683c29f980000",
+                            "0x62ade11c",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x617661782f757364",
+                            "0xd1caba5b2e0ec000",
+                            "0x62ade11c",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x736869622f757364",
+                            "0x723b87623ff",
+                            "0x62ade11b",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x6461692f757364",
+                            "0xddc2a8c6e140000",
+                            "0x62ade11d",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x757364742f757364",
+                            "0xddc45d5596be000",
+                            "0x62ade11e",
+                            "0x706f6e7469732d6269747374616d70",
+                            "0x757364632f757364",
+                            "0xde1fe1eaf827f80",
+                            "0x62ade11e",
+                            "0x706f6e7469732d6269747374616d70"
+                        ],
+                        "caller_address": "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd",
+                        "class_hash": "0x46f5d4858b8a33b3d4c156b5e1e60ac198b39d9d57de842be859435ffa22d6a",
+                        "contract_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x6274632f757364",
+                                    "0x40e8e85219e66000000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 0
+                            },
+                            {
+                                "data": [
+                                    "0x6574682f757364",
+                                    "0x36112683c29f980000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 1
+                            },
+                            {
+                                "data": [
+                                    "0x617661782f757364",
+                                    "0xd1caba5b2e0ec000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 2
+                            },
+                            {
+                                "data": [
+                                    "0x736869622f757364",
+                                    "0x723b87623ff",
+                                    "0x62ade11b",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 3
+                            },
+                            {
+                                "data": [
+                                    "0x6461692f757364",
+                                    "0xddc2a8c6e140000",
+                                    "0x62ade11d",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 4
+                            },
+                            {
+                                "data": [
+                                    "0x757364742f757364",
+                                    "0xddc45d5596be000",
+                                    "0x62ade11e",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 5
+                            },
+                            {
+                                "data": [
+                                    "0x757364632f757364",
+                                    "0xde1fe1eaf827f80",
+                                    "0x62ade11e",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "keys": [
+                                    "0x1528ad871232e93e9974417d96e53e377a424db7e1be9444f20d90cf87d0ffc"
+                                ],
+                                "order": 6
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 133,
+                                "range_check_builtin": 379
+                            },
+                            "n_memory_holes": 1233,
+                            "n_steps": 11239
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6274632f757364",
+                                    "0x40e8e85219e66000000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6574682f757364",
+                                    "0x36112683c29f980000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x617661782f757364",
+                                    "0xd1caba5b2e0ec000",
+                                    "0x62ade11c",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x736869622f757364",
+                                    "0x723b87623ff",
+                                    "0x62ade11b",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x6461692f757364",
+                                    "0xddc2a8c6e140000",
+                                    "0x62ade11d",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 20,
+                                    "n_steps": 306
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364742f757364",
+                                    "0xddc45d5596be000",
+                                    "0x62ade11e",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x40c3a210840bd14edc54f2b81150f976f120f46fb37478d2790d6e0dcf4373d",
+                                "contract_address": "0x7e05e4dea8a62988d9a06ea47bdac34c759a413db5b358e4a3a3d691d9d89e4",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 1,
+                                        "range_check_builtin": 3
+                                    },
+                                    "n_memory_holes": 11,
+                                    "n_steps": 88
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x3a1ce9f6e161d23c2e8f1b6a4a30bed93c6264142611220eef9ecae3e3292fd"
+                                ],
+                                "selector": "0x2c12e79f09880c90a918c4e17c9400dc83c88ece7512dd878998ed78ac667f6"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x757364632f757364",
+                                    "0xde1fe1eaf827f80",
+                                    "0x62ade11e",
+                                    "0x706f6e7469732d6269747374616d70"
+                                ],
+                                "caller_address": "0x13befe6eda920ce4af05a50a67bd808d67eee6ba47bb0892bef2d630eaf1bba",
+                                "class_hash": "0x6dec89ec27ef0d953c54b896da476fa22c14d08b618df43b9718079a4ca6592",
+                                "contract_address": "0x72fa0c2d3427353f372b94614f2ed5e9da6ec358fd720cf7706be0ee42a1449",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 9
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 302
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0x3bc15d7b47936b8b53e607bd23d253c598b26024748b5621b4213ed303d2634"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x3451875d57805682e40d0ad8e604fc4cc5f949d14ca8228d4a2eaeee7f48688"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x2af6baf5181757287a5d025a6f7109db8e12329eb8b6be644f3e281017babbe",
+                "0x12899d8432b6d61e50e05ecca4b61f1d32ade4ec9a6618d1765710edae3dcab"
+            ],
+            "transaction_hash": "0x525325372496ebb75b1e29f05c3bc150914864737a804b17dbd6495990c2edb"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                    "0x2bc198b624f3bdc3b43d8b7cc3228c3e11a1c75343b8f2d55064098065d8fb8",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0x0",
+                    "0x1",
+                    "0x54f0b25c4b916cf31788da91478e5298f3c016d7473e6cbdb1e7f540253085f",
+                    "0x1c"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x70c1584818901e46c973f4857aeaa26139861b16a83a914afa785f3c05d2527",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 9,
+                        "range_check_builtin": 24
+                    },
+                    "n_memory_holes": 84,
+                    "n_steps": 1091
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                            "0x2bc198b624f3bdc3b43d8b7cc3228c3e11a1c75343b8f2d55064098065d8fb8",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0x0",
+                            "0x1",
+                            "0x54f0b25c4b916cf31788da91478e5298f3c016d7473e6cbdb1e7f540253085f",
+                            "0x1c"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x70c1584818901e46c973f4857aeaa26139861b16a83a914afa785f3c05d2527",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x64911c96a1ef58d401346a0286b88354f4aad57c50b513e547ac7dc6e1805c2",
+                                    "0x2",
+                                    "0x1",
+                                    "0x1"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 1
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 9,
+                                "range_check_builtin": 24
+                            },
+                            "n_memory_holes": 74,
+                            "n_steps": 1031
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x0",
+                                    "0x1",
+                                    "0x54f0b25c4b916cf31788da91478e5298f3c016d7473e6cbdb1e7f540253085f"
+                                ],
+                                "caller_address": "0x70c1584818901e46c973f4857aeaa26139861b16a83a914afa785f3c05d2527",
+                                "class_hash": "0x61cad333ef494162645f37e3ba0cafe40998c0475c3c3cc1bbb6c5cdb7d2765",
+                                "contract_address": "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 9,
+                                        "range_check_builtin": 20
+                                    },
+                                    "n_memory_holes": 68,
+                                    "n_steps": 613
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0x0",
+                                            "0x1",
+                                            "0x54f0b25c4b916cf31788da91478e5298f3c016d7473e6cbdb1e7f540253085f"
+                                        ],
+                                        "caller_address": "0x70c1584818901e46c973f4857aeaa26139861b16a83a914afa785f3c05d2527",
+                                        "class_hash": "0x759b7132014837172c72c97088c7b6f7e907fc880796ccaac978cdb90336de8",
+                                        "contract_address": "0x47cd213102d3c063b936c033a6ab2ece8e2973c41f0d87313b80be0e0b22aaf",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x54f0b25c4b916cf31788da91478e5298f3c016d7473e6cbdb1e7f540253085f",
+                                                    "0x70c1584818901e46c973f4857aeaa26139861b16a83a914afa785f3c05d2527"
+                                                ],
+                                                "keys": [
+                                                    "0x18b0fc0291b036fcb7a6c0f415f2ecff5aa7b9922be0bd9b8abeb93dc5efeea"
+                                                ],
+                                                "order": 0
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 9,
+                                                "range_check_builtin": 20
+                                            },
+                                            "n_memory_holes": 65,
+                                            "n_steps": 558
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1",
+                                            "0x1"
+                                        ],
+                                        "selector": "0x2bc198b624f3bdc3b43d8b7cc3228c3e11a1c75343b8f2d55064098065d8fb8"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x1",
+                                    "0x1"
+                                ],
+                                "selector": "0x2bc198b624f3bdc3b43d8b7cc3228c3e11a1c75343b8f2d55064098065d8fb8"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x1"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x1"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x39548801e611b3f61daec2923135fe4e6f2b92cb9b3944d2f870c90fd48ad8a",
+                "0x6d3b5c3005541d12974e6d55a0da8864b39709d9a2387b45f18f07b88b6e728"
+            ],
+            "transaction_hash": "0x64911c96a1ef58d401346a0286b88354f4aad57c50b513e547ac7dc6e1805c2"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                    "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                    "0x0",
+                    "0x3",
+                    "0x3",
+                    "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                    "0x16345785d8a0000",
+                    "0x0",
+                    "0x1d"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 2,
+                        "range_check_builtin": 35
+                    },
+                    "n_memory_holes": 42,
+                    "n_steps": 1404
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x1",
+                            "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                            "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26",
+                            "0x0",
+                            "0x3",
+                            "0x3",
+                            "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                            "0x16345785d8a0000",
+                            "0x0",
+                            "0x1d"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x10e8a6010980156daaebe32efbc5588f028e7b1576c8f8c57a0ded21c8927a3",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 1
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 2,
+                                "range_check_builtin": 35
+                            },
+                            "n_memory_holes": 32,
+                            "n_steps": 1344
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                                    "0x16345785d8a0000",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 2,
+                                        "range_check_builtin": 31
+                                    },
+                                    "n_memory_holes": 26,
+                                    "n_steps": 952
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "DELEGATE",
+                                        "calldata": [
+                                            "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                                            "0x16345785d8a0000",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                                        "class_hash": "0x339e704d3ae446abefd8ed572bc497d403dfc77a891838d5a4c3aa4b3d8dcf2",
+                                        "contract_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                                                    "0x16345785d8a0000",
+                                                    "0x0",
+                                                    "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1"
+                                                ],
+                                                "keys": [
+                                                    "0x194fc63c49b0f07c8e7a78476844837255213824bd6cb81e0ccfb949921aad1"
+                                                ],
+                                                "order": 0
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 31
+                                            },
+                                            "n_memory_holes": 23,
+                                            "n_steps": 892
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                                                    "0x16345785d8a0000",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                "class_hash": "0xd0e183745e9dae3e4e78a8ffedcce0903fc4900beace4e0abf192d4c202da3",
+                                                "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 2,
+                                                        "range_check_builtin": 17
+                                                    },
+                                                    "n_memory_holes": 23,
+                                                    "n_steps": 559
+                                                },
+                                                "internal_calls": [
+                                                    {
+                                                        "call_type": "DELEGATE",
+                                                        "calldata": [
+                                                            "0x481724fdcd4373e80572bfd069a9053a5d460d0b45edb589445ac465077c4f1",
+                                                            "0x16345785d8a0000",
+                                                            "0x0"
+                                                        ],
+                                                        "caller_address": "0x73314940630fd6dcda0d772d4c972c4e0a9946bef9dabf4ef84eda8ef542b82",
+                                                        "class_hash": "0x28d7d394810ad8c52741ad8f7564717fd02c10ced68657a81d0b6710ce22079",
+                                                        "contract_address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+                                                        "entry_point_type": "EXTERNAL",
+                                                        "events": [],
+                                                        "execution_resources": {
+                                                            "builtin_instance_counter": {
+                                                                "bitwise_builtin": 0,
+                                                                "ecdsa_builtin": 0,
+                                                                "output_builtin": 0,
+                                                                "pedersen_builtin": 2,
+                                                                "range_check_builtin": 17
+                                                            },
+                                                            "n_memory_holes": 20,
+                                                            "n_steps": 499
+                                                        },
+                                                        "internal_calls": [],
+                                                        "messages": [],
+                                                        "result": [],
+                                                        "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                                    }
+                                                ],
+                                                "messages": [],
+                                                "result": [],
+                                                "selector": "0xd63a78e4cd7fb4c41bc18d089154af78d400a5e837f270baea6cf8db18c8dd"
+                                            }
+                                        ],
+                                        "messages": [
+                                            {
+                                                "order": 0,
+                                                "payload": [
+                                                    "0x0",
+                                                    "0xf1d75e75e375d0656bedad4c0298f4c4668b3e21",
+                                                    "0x16345785d8a0000",
+                                                    "0x0"
+                                                ],
+                                                "to_address": "0xc3511006C04EF1d78af4C8E0e74Ec18A6E64Ff9e"
+                                            }
+                                        ],
+                                        "result": [],
+                                        "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [],
+                                "selector": "0xe48e45e0642d5f170bb832c637926f4c85b77d555848b693304600c4275f26"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x2f6953022c08a00580e84f7c21864b43228cefbfa39ec8a5d7cfaec6d4c0a83",
+                "0x144cb8e192f7e614be70f0b40edceb8164ccae3139686d30a34f2bc2c9d4ae9"
+            ],
+            "transaction_hash": "0x10e8a6010980156daaebe32efbc5588f028e7b1576c8f8c57a0ded21c8927a3"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x2",
+                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                    "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                    "0x0",
+                    "0x3",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada",
+                    "0x3",
+                    "0xa",
+                    "0xd",
+                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                    "0x30a7f24f810e",
+                    "0x0",
+                    "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                    "0x30a7f24f810e",
+                    "0x0",
+                    "0x72509a70a4b16427",
+                    "0x0",
+                    "0x149beac3",
+                    "0x0",
+                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                    "0x62adee62",
+                    "0x13"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918",
+                "contract_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 29,
+                        "range_check_builtin": 502
+                    },
+                    "n_memory_holes": 322,
+                    "n_steps": 8212
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "DELEGATE",
+                        "calldata": [
+                            "0x2",
+                            "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                            "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c",
+                            "0x0",
+                            "0x3",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada",
+                            "0x3",
+                            "0xa",
+                            "0xd",
+                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                            "0x30a7f24f810e",
+                            "0x0",
+                            "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                            "0x30a7f24f810e",
+                            "0x0",
+                            "0x72509a70a4b16427",
+                            "0x0",
+                            "0x149beac3",
+                            "0x0",
+                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                            "0x62adee62",
+                            "0x13"
+                        ],
+                        "caller_address": "0x0",
+                        "class_hash": "0x3e327de1c40540b98d05cbcb13552008e36f0ec8d61d46956d2f9752c294328",
+                        "contract_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [
+                            {
+                                "data": [
+                                    "0x477173a0d6cca55990b35dbd721093dbd132e5b8bdfcaa0298a8b61cc015ad",
+                                    "0x5",
+                                    "0x1",
+                                    "0x72e3a95de9b26371",
+                                    "0x0",
+                                    "0x14b66ddf",
+                                    "0x0"
+                                ],
+                                "keys": [
+                                    "0x5ad857f66a5b55f1301ff1ed7e098ac6d4433148f0b72ebc4a2945ab85ad53"
+                                ],
+                                "order": 5
+                            }
+                        ],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 1,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 29,
+                                "range_check_builtin": 502
+                            },
+                            "n_memory_holes": 298,
+                            "n_steps": 8152
+                        },
+                        "internal_calls": [
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                    "0x30a7f24f810e",
+                                    "0x0"
+                                ],
+                                "caller_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                "contract_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [
+                                    {
+                                        "data": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                            "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                            "0x30a7f24f810e",
+                                            "0x0"
+                                        ],
+                                        "keys": [
+                                            "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+                                        ],
+                                        "order": 0
+                                    }
+                                ],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 4,
+                                        "range_check_builtin": 45
+                                    },
+                                    "n_memory_holes": 22,
+                                    "n_steps": 530
+                                },
+                                "internal_calls": [],
+                                "messages": [],
+                                "result": [
+                                    "0x1"
+                                ],
+                                "selector": "0x219209e083275171774dab1df80982e9df2096516f06319c5c6d71ae0a8480c"
+                            },
+                            {
+                                "call_type": "CALL",
+                                "calldata": [
+                                    "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                    "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                    "0x30a7f24f810e",
+                                    "0x0",
+                                    "0x72509a70a4b16427",
+                                    "0x0",
+                                    "0x149beac3",
+                                    "0x0",
+                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                    "0x62adee62"
+                                ],
+                                "caller_address": "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                "class_hash": "0x8ae22dfa1772a2229440f31591f8b5d58b251c3f6784ac3ceb23e39fe5ab10",
+                                "contract_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                "entry_point_type": "EXTERNAL",
+                                "events": [],
+                                "execution_resources": {
+                                    "builtin_instance_counter": {
+                                        "bitwise_builtin": 0,
+                                        "ecdsa_builtin": 0,
+                                        "output_builtin": 0,
+                                        "pedersen_builtin": 25,
+                                        "range_check_builtin": 453
+                                    },
+                                    "n_memory_holes": 260,
+                                    "n_steps": 7096
+                                },
+                                "internal_calls": [
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                            "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                        "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 2,
+                                                "range_check_builtin": 3
+                                            },
+                                            "n_memory_holes": 11,
+                                            "n_steps": 92
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7"
+                                        ],
+                                        "selector": "0x309c9f0a77702009c3a391419d43d5c99f66949894aefa563d0ce6551ff2a10"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                            "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                            "0x30a7f24f810e",
+                                            "0x0"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                    "0x30a7f24f810e",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x99cd8bde557814842a3121e8ddfd433a539b8c9f14bf31ebf108d12e6196e9"
+                                                ],
+                                                "order": 1
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0x0",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff"
+                                                ],
+                                                "order": 2
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 8,
+                                                "range_check_builtin": 46
+                                            },
+                                            "n_memory_holes": 66,
+                                            "n_steps": 1004
+                                        },
+                                        "internal_calls": [],
+                                        "messages": [],
+                                        "result": [
+                                            "0x1"
+                                        ],
+                                        "selector": "0x41b033f4a31df8067c24d1e9b550a2ce75fd4a29e1147af9752174f0e6cb20"
+                                    },
+                                    {
+                                        "call_type": "CALL",
+                                        "calldata": [
+                                            "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4"
+                                        ],
+                                        "caller_address": "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                        "class_hash": "0x1548310c142873700bd7c8b564b162144f2b84741f3666f463f8d471311fa0",
+                                        "contract_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                        "entry_point_type": "EXTERNAL",
+                                        "events": [
+                                            {
+                                                "data": [
+                                                    "0x9dc5af034057feb0cdb32a7ff69",
+                                                    "0x0",
+                                                    "0x1c719518a072e5e6ff4",
+                                                    "0x0"
+                                                ],
+                                                "keys": [
+                                                    "0xe14a408baf7f453312eec68e9b7d728ec5337fbdf671f917ee8c80f3255232"
+                                                ],
+                                                "order": 3
+                                            },
+                                            {
+                                                "data": [
+                                                    "0x1ea2f12a70ad6a052f99a49dace349996a8e968a0d6d4e9ec34e0991e6d5e5e",
+                                                    "0x72e3a95de9b26371",
+                                                    "0x0",
+                                                    "0x14b66ddf",
+                                                    "0x0",
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4"
+                                                ],
+                                                "keys": [
+                                                    "0x243e1de00e8a6bc1dfa3e950e6ade24c52e4a25de4dee7fb5affe918ad1e744"
+                                                ],
+                                                "order": 4
+                                            }
+                                        ],
+                                        "execution_resources": {
+                                            "builtin_instance_counter": {
+                                                "bitwise_builtin": 0,
+                                                "ecdsa_builtin": 0,
+                                                "output_builtin": 0,
+                                                "pedersen_builtin": 15,
+                                                "range_check_builtin": 387
+                                            },
+                                            "n_memory_holes": 183,
+                                            "n_steps": 5472
+                                        },
+                                        "internal_calls": [
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x9dc5af03405f2ceb6391c5a62da",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1c719518a074314ddd3",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x1ce6d0750cd456eec8ec9db5aecd0c90e580e1d06fb4cd055d7e880c7baf95c",
+                                                "contract_address": "0x413ba8d51ec05be863eb82314f0cf0ffceff949e76c87cae0a4bd7f89cfc2b1",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 0,
+                                                        "range_check_builtin": 0
+                                                    },
+                                                    "n_memory_holes": 0,
+                                                    "n_steps": 46
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x845a08a51fd77880cb14b0e33c63bb1b6d98e77c57673f0aa3e31a9fd2ca64"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x72e3a95de9b26371",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 21
+                                                    },
+                                                    "n_memory_holes": 44,
+                                                    "n_steps": 481
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x3024fc3535164ef42dcd634de674d8c779f1c2b8dfa17a67dc829374ea390d4",
+                                                    "0x14b66ddf",
+                                                    "0x0"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 4,
+                                                        "range_check_builtin": 21
+                                                    },
+                                                    "n_memory_holes": 44,
+                                                    "n_steps": 481
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1"
+                                                ],
+                                                "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x1ca5dedf1612b1ffb035e838ac09d70e500d22cf9cd0de4bebcef8553506fdb",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x9dc5af034057feb0cdb32a7ff69",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            },
+                                            {
+                                                "call_type": "CALL",
+                                                "calldata": [
+                                                    "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7"
+                                                ],
+                                                "caller_address": "0x20d17664962dc4b49ab65b4b89555f383f040da5f62c18a0834acea246bc7b7",
+                                                "class_hash": "0x7af369f1362ea4597885254aac079799c2fbe00ac0be0ec75bd1c27ae4c8adb",
+                                                "contract_address": "0x5f405f9650c7ef663c87352d280f8d359ad07d200c0e5450cb9d222092dc756",
+                                                "entry_point_type": "EXTERNAL",
+                                                "events": [],
+                                                "execution_resources": {
+                                                    "builtin_instance_counter": {
+                                                        "bitwise_builtin": 0,
+                                                        "ecdsa_builtin": 0,
+                                                        "output_builtin": 0,
+                                                        "pedersen_builtin": 1,
+                                                        "range_check_builtin": 3
+                                                    },
+                                                    "n_memory_holes": 11,
+                                                    "n_steps": 94
+                                                },
+                                                "internal_calls": [],
+                                                "messages": [],
+                                                "result": [
+                                                    "0x1c719518a072e5e6ff4",
+                                                    "0x0"
+                                                ],
+                                                "selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e"
+                                            }
+                                        ],
+                                        "messages": [],
+                                        "result": [
+                                            "0x72e3a95de9b26371",
+                                            "0x0",
+                                            "0x14b66ddf",
+                                            "0x0"
+                                        ],
+                                        "selector": "0x3e8cfd4725c1e28fa4a6e3e468b4fcf75367166b850ac5f04e33ec843e82c1"
+                                    }
+                                ],
+                                "messages": [],
+                                "result": [
+                                    "0x72e3a95de9b26371",
+                                    "0x0",
+                                    "0x14b66ddf",
+                                    "0x0"
+                                ],
+                                "selector": "0x2e875d1c86df033547c5c7839d8b6e3641de29ee1f708bbce99743b34272ada"
+                            }
+                        ],
+                        "messages": [],
+                        "result": [
+                            "0x1",
+                            "0x72e3a95de9b26371",
+                            "0x0",
+                            "0x14b66ddf",
+                            "0x0"
+                        ],
+                        "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x1",
+                    "0x72e3a95de9b26371",
+                    "0x0",
+                    "0x14b66ddf",
+                    "0x0"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x6b291f4bc9c3b8d13ceb08ab70327ec6e403f42ffbd0ef6f56e56062d1a33bf",
+                "0x262b6712b15ac97b35b73a931cdd86422d15e1ba2049761cba62cec16b68853"
+            ],
+            "transaction_hash": "0x477173a0d6cca55990b35dbd721093dbd132e5b8bdfcaa0298a8b61cc015ad"
+        },
+        {
+            "function_invocation": {
+                "call_type": "CALL",
+                "calldata": [
+                    "0x1",
+                    "0x6e7ba466e432eb83f3ac382c8353dac777267d006f9e33e9a0f795f91c9a80b",
+                    "0xbea442b3d686db4af016ef77780743e6c17d2f77c23ef096218c96e47c150c",
+                    "0x0",
+                    "0x0",
+                    "0x0",
+                    "0x1"
+                ],
+                "caller_address": "0x0",
+                "class_hash": "0x726edb35cc732c1b3661fd837592033bd85ae8dde31533c35711fb0422d8993",
+                "contract_address": "0x46854a8c52697d7d2a3f356c406754961407bcb7f642707c9aaa5e7b1ca5afd",
+                "entry_point_type": "EXTERNAL",
+                "events": [],
+                "execution_resources": {
+                    "builtin_instance_counter": {
+                        "bitwise_builtin": 0,
+                        "ecdsa_builtin": 1,
+                        "output_builtin": 0,
+                        "pedersen_builtin": 0,
+                        "range_check_builtin": 4
+                    },
+                    "n_memory_holes": 3,
+                    "n_steps": 450
+                },
+                "internal_calls": [
+                    {
+                        "call_type": "CALL",
+                        "calldata": [],
+                        "caller_address": "0x46854a8c52697d7d2a3f356c406754961407bcb7f642707c9aaa5e7b1ca5afd",
+                        "class_hash": "0x3d146bf544920d86e90feaa68b6acf58cb8a64096ab5337ca205b4e48d2cf1f",
+                        "contract_address": "0x6e7ba466e432eb83f3ac382c8353dac777267d006f9e33e9a0f795f91c9a80b",
+                        "entry_point_type": "EXTERNAL",
+                        "events": [],
+                        "execution_resources": {
+                            "builtin_instance_counter": {
+                                "bitwise_builtin": 0,
+                                "ecdsa_builtin": 0,
+                                "output_builtin": 0,
+                                "pedersen_builtin": 0,
+                                "range_check_builtin": 1
+                            },
+                            "n_memory_holes": 0,
+                            "n_steps": 113
+                        },
+                        "internal_calls": [],
+                        "messages": [],
+                        "result": [
+                            "0x3",
+                            "0x1",
+                            "0x2",
+                            "0x3"
+                        ],
+                        "selector": "0xbea442b3d686db4af016ef77780743e6c17d2f77c23ef096218c96e47c150c"
+                    }
+                ],
+                "messages": [],
+                "result": [
+                    "0x4",
+                    "0x3",
+                    "0x1",
+                    "0x2",
+                    "0x3"
+                ],
+                "selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad"
+            },
+            "signature": [
+                "0x3a5e1d9f81e48ce9fe15415263b133c3e097b219ecdc63643a1bfa7a5df783e",
+                "0x19dba020485bf7eb48ecfabf7d8c375605be17d15d48fd77410efae293dc989"
+            ],
+            "transaction_hash": "0x4d73269f4251b2dc0a421a86a2c8c8d04a97a5046fbfe2d8fa037c954b6b2dd"
+        }
+    ]
+}

--- a/tests/data/traces-testnet-block-243810_results.json
+++ b/tests/data/traces-testnet-block-243810_results.json
@@ -1,0 +1,108 @@
+{
+    "0x59949c78d504055e1937626115e7e83e25db677b5067129fb032e2eceb45d9": [
+        "0x0"
+    ],
+    "0x1b50749bd19e94c64fb71771c4c92c779fdeac0c281f3305e0b5b5214697b8c": [],
+    "0x408daf26b562ab9a890b9e2ca39b645ca5af4809463c9dda2a92934d575a73b": [
+        "0x1"
+    ],
+    "0x6606fd04124b3264bf6295580bda96455efb7713c2ef9d701f6d5b8c65d409a": [
+        "0x1"
+    ],
+    "0x291ffe912a6d06785b29c28b493b2a5bbf50736f8c2116ed9d083d10bfd61e6": [
+        "0x1",
+        "0x78294edbfb5e2fc4d",
+        "0x0"
+    ],
+    "0x4a94a65efa1af680e65b7b4d46850deecc493e5c4c3a7de17b25d1bec6ea7c": [
+        "0x1",
+        "0x1",
+        "0xad781b168878b922d",
+        "0x0",
+        "0xc705a3",
+        "0x0",
+        "0x2e0bb9e8e52c",
+        "0x0"
+    ],
+    "0x357787f7ff27bb9cff4bcf1953826f99ac00e5ab1da5b595854c39e35a664d4": [],
+    "0x75a828662d76bacaba069a75ccc892c65bcabb15a4214a22f156ec1b46887a8": [
+        "0x0"
+    ],
+    "0x3f9404e5fef5ddf80c5c012b3bd1b9afef61b57e08c40912cef861ff8e2676": [],
+    "0x763b470debd148744fa6aa3eadd385870bfc6f645374c4f55c8d26ef242d0e": [
+        "0x0"
+    ],
+    "0x1b62451ef233a58120dfc6757f90ec86221379ec9b7e57260c55432ba7e30a4": [],
+    "0xe28d927a92a11eaa0d68062cc63a35c7cf75b730e9d52a27822e08ced4798c": [
+        "0x0"
+    ],
+    "0x6ea17c1188070efe7504c288969424e5c750fd667e5074819daef14f2f98051": [
+        "0x1",
+        "0x1109e5157d1a9f8d0",
+        "0x0",
+        "0x363d05301b3fadc74b",
+        "0x0"
+    ],
+    "0x552334e3dfb31d87d62eb9c1483551c30f03c91e5aa7af376df030646c21123": [
+        "0x3",
+        "0x1",
+        "0x2",
+        "0x3"
+    ],
+    "0x6d279fe1c9cfb0540d527dec02a0c2b6f1417e91f00084b34e9c63bca0b28a8": [
+        "0x1"
+    ],
+    "0xbd418c0c10dcd5502df78d79b4d268831354f8b4b4dc7eee88b961323dffff": [],
+    "0x3f094122db852d07214fa15f38ec2bdd57452dc6f35091cc249cad3a661c5e4": [
+        "0x1",
+        "0x2",
+        "0x6c6b935b8bbd400000",
+        "0x0",
+        "0x7c0487c",
+        "0x0"
+    ],
+    "0x5c3f43c0c65b3bcd663a2999a9fbb6550fa3aa78c6d92d2f30cee072a02b72b": [],
+    "0x311b496d373b0776b1f12cd500138f228af8f45664530116bc501a6e2f4b40f": [],
+    "0x3e83a229f544b538f9bf4b79860edcabfe3a2de02b5cb7ff11a8c76666c0fa7": [],
+    "0x1d808749d0a008d6cea1d48197251ab4194df154984c20b39e638af78aa2a1b": [
+        "0x35ab060f27e60e175e",
+        "0x0"
+    ],
+    "0xb67cc869b35e043c07a74612c531afd7827ce4fb4f3d9d1c8e25b934feb991": [
+        "0x0"
+    ],
+    "0x2da9cad86f76f406a10f2b4878b108a02f49e0d749abdadec030d42bc8c2f54": [
+        "0x1"
+    ],
+    "0x577e8a98102dbe78e744dcff17cae0d9832a25f4daf7485c2a070741e2fb9c": [
+        "0x1",
+        "0x1",
+        "0x1270e6723177cdc84",
+        "0x0"
+    ],
+    "0x6775350096f21c08fafa84ac75170ea98a8c1fdb6548ca8ad951ff9a5abb923": [
+        "0x0"
+    ],
+    "0x53787fbf6680150741163cf2406c2a1710de4cc6c6079d978081ff94156002b": [],
+    "0x525325372496ebb75b1e29f05c3bc150914864737a804b17dbd6495990c2edb": [
+        "0x0"
+    ],
+    "0x64911c96a1ef58d401346a0286b88354f4aad57c50b513e547ac7dc6e1805c2": [
+        "0x1",
+        "0x1"
+    ],
+    "0x10e8a6010980156daaebe32efbc5588f028e7b1576c8f8c57a0ded21c8927a3": [],
+    "0x477173a0d6cca55990b35dbd721093dbd132e5b8bdfcaa0298a8b61cc015ad": [
+        "0x1",
+        "0x72e3a95de9b26371",
+        "0x0",
+        "0x14b66ddf",
+        "0x0"
+    ],
+    "0x4d73269f4251b2dc0a421a86a2c8c8d04a97a5046fbfe2d8fa037c954b6b2dd": [
+        "0x3",
+        "0x1",
+        "0x2",
+        "0x3"
+    ]
+}

--- a/tests/functional/test_contract.py
+++ b/tests/functional/test_contract.py
@@ -152,11 +152,10 @@ def test_array_inputs(contract):
 @pytest.mark.parametrize(
     "method, returndata_expected, return_value_expected",
     [
-        ("array", ["0x4", "0x3", "0x1", "0x2", "0x3"], [1, 2, 3]),
+        ("array", ["0x3", "0x1", "0x2", "0x3"], [1, 2, 3]),
         (
             "array_complex_struct",
             [
-                "0x10",
                 "0x3",
                 "0x0",
                 "0x7b",
@@ -190,7 +189,7 @@ def test_array_inputs(contract):
         ),
         (
             "array_uint256",
-            ["0x7", "0x3", "0x7b", "0x0", "0x0", "0x7b", "0x0", "0x0"],
+            ["0x3", "0x7b", "0x0", "0x0", "0x7b", "0x0", "0x0"],
             [
                 123,
                 41854731131275431005995076714107490009088,
@@ -199,18 +198,17 @@ def test_array_inputs(contract):
         ),
         (
             "complex_struct",
-            ["0x5", "0x4d2", "0x7b", "0x0", "0x0", "0x7b"],
+            ["0x4d2", "0x7b", "0x0", "0x0", "0x7b"],
             {
                 "timestamp": 1234,
                 "value0": 123,
                 "value1": 41854731131275431005995076714107490009088,
             },
         ),
-        ("felt", ["0x1", "0x2"], 2),
+        ("felt", ["0x2"], 2),
         (
             "mix",
             [
-                "0xd",
                 "0x1",
                 "0x2",
                 "0x3",
@@ -234,10 +232,10 @@ def test_array_inputs(contract):
                 41854731131275431005995076714107490009088,
             ),
         ),
-        ("uint256", ["0x2", "0x1", "0x0"], 1),
+        ("uint256", ["0x1", "0x0"], 1),
         (
             "uint256s",
-            ["0x6", "0x7b", "0x0", "0x0", "0x7b", "0x0", "0x0"],
+            ["0x7b", "0x0", "0x0", "0x7b", "0x0", "0x0"],
             (
                 123,
                 41854731131275431005995076714107490009088,

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -2,10 +2,12 @@ import pytest
 from ape.exceptions import ApeException, ContractLogicError, OutOfGasError
 from hexbytes import HexBytes
 from starknet_py.net.client_errors import ClientError, ContractNotFoundError
+from starknet_py.net.client_models import BlockSingleTransactionTrace
 from starknet_py.transaction_exceptions import TransactionRejectedError
 
 from ape_starknet.exceptions import StarknetProviderError
 from ape_starknet.utils import (
+    extract_trace_data,
     get_random_private_key,
     get_virtual_machine_error,
     is_checksum_address,
@@ -84,3 +86,13 @@ def test_to_checksum_address(account):
 def test_get_virtual_machine_error(exception, expected):
     error = get_virtual_machine_error(exception)
     assert str(error) == str(expected)
+
+
+def test_extract_trace_data(traces_testnet_243810, traces_testnet_243810_results):
+    for trace in traces_testnet_243810:
+        trace_object = BlockSingleTransactionTrace(**trace)
+        trace_data = extract_trace_data(trace_object)
+        assert isinstance(trace_data, dict)
+
+        expected_result = traces_testnet_243810_results[trace_object.transaction_hash]
+        assert trace_data["result"] == expected_result


### PR DESCRIPTION
### What I did

I hope to end the "leading number" mess in transactions return data.

~Note: the patch requires #67 to be merged first.~ :heavy_check_mark: 

### How I did it

### How to verify it

Internal tests.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
