### PR TITLE
chore: upgrade starknet dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
         "ethpm-types>=0.3.3,<0.4",
         # ** Starknet Ecosystem **
         "cairo-lang>=0.9.1,<0.10",
-        "starknet.py>=0.4.5a0,<0.5",
+        "starknet.py>=0.4.6a0,<0.5",
         "starknet-devnet>=0.2.10,<0.3",
     ],
     entry_points={"ape_cli_subcommands": ["ape_starknet=ape_starknet._cli:cli"]},

--- a/setup.py
+++ b/setup.py
@@ -57,15 +57,17 @@ setup(
     url="https://github.com/ApeWorX/ape-starknet",
     include_package_data=True,
     install_requires=[
-        "cairo-lang>=0.9.1,<0.10",
         "click>=8.1.0,<8.2",
         "hexbytes>=0.2.2,<0.3",
         "pydantic>=1.9.0,<2.0",
+        "importlib-metadata ; python_version<'3.8'",
+        # ** ApeWorX maintained **
         "eth-ape>=0.4.4,<0.5",
         "ethpm-types>=0.3.3,<0.4",
-        "starknet.py>=0.4.4a0,<0.5",
-        "starknet-devnet>=0.2.9,<0.3",
-        "importlib-metadata ; python_version<'3.8'",
+        # ** Starknet Ecosystem **
+        "cairo-lang>=0.9.1,<0.10",
+        "starknet.py>=0.4.5a0,<0.5",
+        "starknet-devnet>=0.2.10,<0.3",
     ],
     entry_points={"ape_cli_subcommands": ["ape_starknet=ape_starknet._cli:cli"]},
     python_requires=">=3.7.2,<3.10",


### PR DESCRIPTION
### What I did

It appears some users are having trouble installing. I noticed they are using `starknet-devnet` 0.2.10 which just came out so this PR upgrades that to ensure that is not a problem.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
