### PR TITLE
perf: make faster

### DIFF
--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -239,7 +239,7 @@ class Starknet(EcosystemAPI, StarknetBase):
         return DeployTransaction(
             salt=salt,
             constructor_calldata=calldata,
-            contract_code=contract.dumps(),
+            contract_code=contract.serialize(),
             token=kwargs.get("token"),
         )
 
@@ -277,7 +277,7 @@ class Starknet(EcosystemAPI, StarknetBase):
         )
         starknet_contract = ContractClass.deserialize(HexBytes(code))
         return DeclareTransaction(
-            contract_type=contract_type, data=starknet_contract.dumps(), **kwargs
+            contract_type=contract_type, data=starknet_contract.serialize(), **kwargs
         )
 
     def create_transaction(self, **kwargs) -> TransactionAPI:

--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -39,6 +39,7 @@ from ape_starknet.utils import (
     get_dict_from_tx_info,
     handle_client_error,
     handle_client_errors,
+    run_until_complete,
 )
 from ape_starknet.utils.basemodel import StarknetBase
 
@@ -78,6 +79,7 @@ class StarknetProvider(ProviderAPI, StarknetBase):
     cached_code: Dict[int, ContractCode] = {}
     local_nonce_cache: Dict[AddressType, int] = {}
     local_balance_cache: Dict[AddressType, int] = {}
+    receipt_cache: Dict[str, ReceiptAPI] = {}
 
     @property
     def connected_client(self) -> GatewayClient:
@@ -239,9 +241,16 @@ class StarknetProvider(ProviderAPI, StarknetBase):
 
     @handle_client_errors
     def get_receipt(self, txn_hash: str) -> ReceiptAPI:
+        if txn_hash in self.receipt_cache:
+            # TODO: Remove once `chain.get_receipt()` fully implemented and released
+            #  (>= eth-ape 0.5.2)
+            return self.receipt_cache[txn_hash]
+
         self.starknet_client.wait_for_tx_sync(txn_hash)
-        txn_info = self.starknet_client.get_transaction_sync(tx_hash=txn_hash)
-        receipt = self.starknet_client.get_transaction_receipt_sync(tx_hash=txn_hash)
+        txn_info, receipt = run_until_complete(
+            self.starknet_client.get_transaction(txn_hash),
+            self.starknet_client.get_transaction_receipt(tx_hash=txn_hash),
+        )
         data = {**asdict(receipt), **get_dict_from_tx_info(txn_info)}
 
         # Handle __execute__ overhead. User only cares for target ABI.
@@ -265,7 +274,11 @@ class StarknetProvider(ProviderAPI, StarknetBase):
             ]
 
         transaction = self.starknet.create_transaction(**data)
-        return self.starknet.decode_receipt({"provider": self, "transaction": transaction, **data})
+        receipt = self.starknet.decode_receipt(
+            {"provider": self, "transaction": transaction, **data}
+        )
+        self.receipt_cache[txn_hash] = receipt
+        return receipt
 
     def get_transactions_by_block(self, block_id: BlockID) -> Iterator[TransactionAPI]:
         block = self._get_block(block_id)

--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -287,7 +287,9 @@ class StarknetProvider(ProviderAPI, StarknetBase):
             self.local_nonce_cache[receipt.sender] = 1
 
         if receipt.sender in self.token_manager.local_balance_cache:
-            self.token_manager.local_balance_cache[receipt.sender] -= receipt.total_transfer_value
+            self.token_manager.local_balance_cache[receipt.sender][
+                "eth"
+            ] -= receipt.total_transfer_value
 
         return receipt
 

--- a/ape_starknet/transactions.py
+++ b/ape_starknet/transactions.py
@@ -87,16 +87,18 @@ class DeclareTransaction(AccountTransaction):
     sender: AddressType
     type: TransactionType = TransactionType.DECLARE
 
-    @property
+    @cached_property
     def starknet_contract(self) -> ContractClass:
         return ContractClass.deserialize(self.data)
 
-    @property
+    @cached_property
     def txn_hash(self) -> HexBytes:
         return calculate_declare_transaction_hash(
             self.starknet_contract,
             self.provider.chain_id,
             self.sender,
+            self.version,
+            self.nonce,
         )
 
     def as_starknet_object(self) -> Declare:
@@ -124,11 +126,11 @@ class DeployTransaction(StarknetTransaction):
     """Ignored"""
     receiver: Optional[AddressType] = Field(None, exclude=True)
 
-    @property
+    @cached_property
     def starknet_contract(self) -> Optional[ContractClass]:
         return ContractClass.deserialize(self.data)
 
-    @property
+    @cached_property
     def txn_hash(self) -> HexBytes:
         contract_address = calculate_contract_address(
             contract_class=self.starknet_contract,
@@ -186,7 +188,7 @@ class InvokeFunctionTransaction(AccountTransaction):
     def entry_point_selector(self) -> int:
         return get_selector_from_name(self.method_abi.name)
 
-    @property
+    @cached_property
     def txn_hash(self) -> HexBytes:
         hash_int = calculate_transaction_hash_common(
             additional_data=[],

--- a/ape_starknet/utils/__init__.py
+++ b/ape_starknet/utils/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+from asyncio import gather
 from dataclasses import asdict
 from json import JSONDecodeError, loads
 from typing import Any, Dict, List, Optional, Union, cast
@@ -241,9 +242,16 @@ def pad_hex_str(value: str, to_length: int = 66) -> str:
     return f"0x{padding}{val}"
 
 
-def run_until_complete(coroutine):
+def run_until_complete(*coroutine):
+    coroutines = list(coroutine)
+    if len(coroutines) > 1:
+        task = gather(*coroutine, return_exceptions=True)
+    else:
+        task = coroutines[0]
+
     loop = asyncio.get_event_loop()
-    return loop.run_until_complete(coroutine)
+    result = loop.run_until_complete(task)
+    return result
 
 
 def to_int(val) -> int:


### PR DESCRIPTION
### What I did

* Track nonce and balances locally
* Cache receipts locally
* Use async smarter in 1 spot
* Used cached_property in more places

Before what took `22.495 seconds` to complete now takes `19.304`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
