### PR TITLE
feat: implement `mine()` in Provider

### DIFF
--- a/ape_starknet/provider.py
+++ b/ape_starknet/provider.py
@@ -56,6 +56,9 @@ class DevnetClient:
     def increase_time(self, amount: int):
         return self._post("increase_time", json={"time": amount})
 
+    def create_block(self):
+        return self._post("create_block")
+
     def _get(self, uri: str, **kwargs):
         return self._request("get", uri, **kwargs)
 
@@ -385,6 +388,10 @@ class StarknetDevnetProvider(SubprocessProvider, StarknetProvider):
         result = self.devnet_client.increase_time(seconds_to_increase)
         if "timestamp_increased_by" not in result:
             raise StarknetProviderError(result)
+
+    def mine(self, num_blocks: int = 1):
+        for index in range(num_blocks):
+            self.devnet_client.create_block()
 
 
 __all__ = ["StarknetProvider", "StarknetDevnetProvider"]

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -82,3 +82,12 @@ def test_set_timestamp(provider, account, contract):
     contract.increase_balance(account.address, 123, sender=account)
     curr_time = time.time()
     assert pytest.approx(curr_time + 8600) == provider.get_block("latest").timestamp
+
+
+def test_mine(provider):
+    block_num = provider.get_block("latest").number
+    provider.mine()
+    next_block_num = provider.get_block("latest").number
+
+    # NOTE: Uses >= in case of x-dist
+    assert next_block_num >= block_num + 1

--- a/tests/functional/test_provider.py
+++ b/tests/functional/test_provider.py
@@ -79,7 +79,7 @@ def test_get_transactions_by_block(provider, account, contract):
 def test_set_timestamp(provider, account, contract):
     start_time = provider.get_block("pending").timestamp
     provider.set_timestamp(start_time + 8600)
-    contract.increase_balance(account.address, 123, sender=account)
+    provider.mine()
     curr_time = time.time()
     assert pytest.approx(curr_time + 8600) == provider.get_block("latest").timestamp
 


### PR DESCRIPTION
### What I did

Adds the `mine()` method to the provider.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
