### PR TITLE
fix: issue with custom calldata in accounts

### DIFF
--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -591,10 +591,9 @@ class BaseStarknetAccount(AccountAPI, StarknetBase):
               transfer if needed.
             salt (Optional[int]): Contract address salt. Needed if wanting to deploy
               to a different address.
-            calldata (Optional[List]): Will default to the account to handle calldata
-              if not given here. Default accounts will check the keyfile for calldata
-              specified on create. Else, will use the default calldata known for common
-              class hashes.
+            calldata (Optional[List]): Custom calldata to provide. Defaults to the
+              calldata in the keyfile, if found. Else, uses what is expected per the
+              class hash, such as the public key.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`: The receipt from the

--- a/ape_starknet/accounts/__init__.py
+++ b/ape_starknet/accounts/__init__.py
@@ -284,9 +284,10 @@ class StarknetAccountContainer(AccountContainerAPI, StarknetBase):
             "private_key": key_pair.private_key,
             "class_hash": class_hash,
         }
-        account_data[
-            "constructor_calldata"
-        ] = constructor_calldata or get_account_constructor_calldata(key_pair, class_hash)
+        constructor_calldata = constructor_calldata or get_account_constructor_calldata(
+            key_pair, class_hash
+        )
+        account_data["constructor_calldata"] = constructor_calldata
 
         if (
             not allow_local_file_store
@@ -509,11 +510,13 @@ class BaseStarknetAccount(AccountAPI, StarknetBase):
             salt=salt or self.salt,
         )
 
-    def get_deploy_account_txn(self, salt: Optional[int] = None) -> DeployAccountTransaction:
+    def get_deploy_account_txn(
+        self, salt: Optional[int] = None, calldata: Optional[List] = None
+    ) -> DeployAccountTransaction:
         txn = DeployAccountTransaction(
             salt=salt or self.salt,
             class_hash=self.class_hash,
-            constructor_calldata=self.constructor_calldata,
+            constructor_calldata=calldata or self.constructor_calldata,
             signature=None,
         )
 
@@ -574,7 +577,10 @@ class BaseStarknetAccount(AccountAPI, StarknetBase):
         raise ValueError(f"Unable to deploy '{contract}'.")
 
     def deploy_account(
-        self, funder: Optional["BaseStarknetAccount"] = None, salt: Optional[int] = None
+        self,
+        funder: Optional["BaseStarknetAccount"] = None,
+        salt: Optional[int] = None,
+        calldata: Optional[List] = None,
     ) -> ReceiptAPI:
         """
         Deploys this account.
@@ -585,12 +591,16 @@ class BaseStarknetAccount(AccountAPI, StarknetBase):
               transfer if needed.
             salt (Optional[int]): Contract address salt. Needed if wanting to deploy
               to a different address.
+            calldata (Optional[List]): Will default to the account to handle calldata
+              if not given here. Default accounts will check the keyfile for calldata
+              specified on create. Else, will use the default calldata known for common
+              class hashes.
 
         Returns:
             :class:`~ape.api.transactions.ReceiptAPI`: The receipt from the
             :class:`~ape_starknet.transactions.DeployAccountTransaction`.
         """
-        txn = self.get_deploy_account_txn(salt)
+        txn = self.get_deploy_account_txn(salt=salt, calldata=calldata)
 
         # NOTE: Because of error handling Ape core, need to trick Ape into thinking
         # the account balance is actually the funder's.
@@ -1042,6 +1052,8 @@ class StarknetKeyfileAccount(BaseStarknetAccount):
             account_data["class_hash"] = class_hash
         if salt:
             account_data["salt"] = salt
+        if constructor_calldata:
+            account_data["constructor_calldata"] = constructor_calldata
 
         data = {**key_file_data, APP_KEY_FILE_KEY: account_data}
         self.key_file_path.write_text(json.dumps(data))

--- a/ape_starknet/accounts/_cli.py
+++ b/ape_starknet/accounts/_cli.py
@@ -71,7 +71,7 @@ def address_option():
 def constructor_calldata_option():
     return click.option(
         "--constructor-calldata",
-        help="Comma separated list of calldata, default tries to be smart.",
+        help="Comma separated list of calldata, default uses keyfile or known inputs.",
     )
 
 

--- a/ape_starknet/ecosystems.py
+++ b/ape_starknet/ecosystems.py
@@ -450,7 +450,9 @@ class Starknet(EcosystemAPI, StarknetBase):
             else None
         )
 
-    def decode_primitive_value(self, value: Any, output_type: Union[str, Tuple, List]) -> int:
+    def decode_primitive_value(
+        self, value: Any, output_type: Union[str, Tuple, List] = "felt"
+    ) -> int:
         return to_int(value)
 
     def decode_calldata(self, abi: Union[ConstructorABI, MethodABI], calldata: bytes) -> Dict:


### PR DESCRIPTION
### What I did

* Fixes issue where custom calldata wouldn't save in accounts on create
* Adds calldata option to deploy so you don't have to use the default from create
* Adds tests

### How I did it

Noticed `decode_primitive_value` was not working so I checked if it was used anywhere and found this. Realized this was not tested and then realized it wasn't working in other ways. Fixed it all.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
